### PR TITLE
Updated the tests to reflect changes in the presenter

### DIFF
--- a/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/gwt/mvp/AdminPresenterTestUtilGwt.java
+++ b/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/gwt/mvp/AdminPresenterTestUtilGwt.java
@@ -16,14 +16,13 @@
 
 package com.gwtplatform.mvp.client.gwt.mvp;
 
-import com.google.web.bindery.event.shared.EventBus;
 import com.google.inject.Inject;
+import com.google.web.bindery.event.shared.EventBus;
 import com.gwtplatform.mvp.client.Presenter;
 import com.gwtplatform.mvp.client.View;
 import com.gwtplatform.mvp.client.annotations.NameToken;
 import com.gwtplatform.mvp.client.annotations.ProxyStandard;
 import com.gwtplatform.mvp.client.proxy.ProxyPlace;
-import com.gwtplatform.mvp.client.proxy.RevealRootContentEvent;
 
 /**
  * A test presenter meant to be run in a GWTTestCase.
@@ -48,12 +47,7 @@ public class AdminPresenterTestUtilGwt extends Presenter<AdminPresenterTestUtilG
 
   @Inject
   public AdminPresenterTestUtilGwt(final EventBus eventBus, final MyView view, final MyProxy proxy) {
-    super(eventBus, view, proxy);
-  }
-
-  @Override
-  protected void revealInParent() {
-    RevealRootContentEvent.fire(this, this);
+    super(eventBus, view, proxy, RevealType.Root);
   }
 }
 

--- a/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/gwt/mvp/MainPresenterTestUtilGwt.java
+++ b/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/gwt/mvp/MainPresenterTestUtilGwt.java
@@ -16,14 +16,13 @@
 
 package com.gwtplatform.mvp.client.gwt.mvp;
 
-import com.google.web.bindery.event.shared.EventBus;
 import com.google.inject.Inject;
+import com.google.web.bindery.event.shared.EventBus;
 import com.gwtplatform.mvp.client.Presenter;
 import com.gwtplatform.mvp.client.View;
 import com.gwtplatform.mvp.client.annotations.NameToken;
 import com.gwtplatform.mvp.client.annotations.ProxyStandard;
 import com.gwtplatform.mvp.client.proxy.ProxyPlace;
-import com.gwtplatform.mvp.client.proxy.RevealRootContentEvent;
 
 /**
  * A test presenter meant to be run in a GWTTestCase.
@@ -48,12 +47,7 @@ public class MainPresenterTestUtilGwt extends Presenter<MainPresenterTestUtilGwt
 
   @Inject
   public MainPresenterTestUtilGwt(final EventBus eventBus, final MyView view, final MyProxy proxy) {
-    super(eventBus, view, proxy);
-  }
-
-  @Override
-  protected void revealInParent() {
-    RevealRootContentEvent.fire(this, this);
+    super(eventBus, view, proxy, RevealType.Root);
   }
 }
 

--- a/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/mvp/MainPresenterTestUtil.java
+++ b/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/mvp/MainPresenterTestUtil.java
@@ -16,11 +16,10 @@
 
 package com.gwtplatform.mvp.client.mvp;
 
-import com.google.web.bindery.event.shared.EventBus;
 import com.google.gwt.event.shared.GwtEvent.Type;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
-
+import com.google.web.bindery.event.shared.EventBus;
 import com.gwtplatform.mvp.client.Presenter;
 import com.gwtplatform.mvp.client.PresenterWidget;
 import com.gwtplatform.mvp.client.View;
@@ -28,7 +27,6 @@ import com.gwtplatform.mvp.client.annotations.ContentSlot;
 import com.gwtplatform.mvp.client.annotations.ProxyStandard;
 import com.gwtplatform.mvp.client.proxy.Proxy;
 import com.gwtplatform.mvp.client.proxy.RevealContentHandler;
-import com.gwtplatform.mvp.client.proxy.RevealRootContentEvent;
 
 /**
  * This is the test presenter.
@@ -58,17 +56,12 @@ public class MainPresenterTestUtil extends Presenter<MainPresenterTestUtil.MyVie
   @Inject
   public MainPresenterTestUtil(final EventBus eventBus, final MyView view,
       final MyProxy proxy, @Named("Sub") PresenterWidget<View> subPresenter) {
-    super(eventBus, view, proxy);
+    super(eventBus, view, proxy, RevealType.Root);
     this.subPresenter = subPresenter;
   }
 
   public void setSubPresenter() {
     setInSlot(TYPE_SetMainContent, subPresenter);
-  }
-
-  @Override
-  protected void revealInParent() {
-    RevealRootContentEvent.fire(this, this);
   }
 }
 

--- a/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/proxy/AsyncEventPresenterTestUtil.java
+++ b/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/proxy/AsyncEventPresenterTestUtil.java
@@ -53,7 +53,7 @@ public class AsyncEventPresenterTestUtil extends
   }
 
   public AsyncEventPresenterTestUtil(EventBus eventBus, MyView view, MyProxy proxy, DispatchAsync dispatcher) {
-    super(eventBus, view, proxy);
+    super(eventBus, view, proxy, RevealType.Root);
     this.dispatcher = dispatcher;
   }
 
@@ -95,11 +95,6 @@ public class AsyncEventPresenterTestUtil extends
   @Override
   public void onAsyncCallFail(AsyncCallFailEvent asyncCallFailEvent) {
     getView().setMessage("Oops, something went wrong...");
-  }
-
-  @Override
-  protected void revealInParent() {
-    RevealRootContentEvent.fire(this, this);
   }
 
   static class MyAction extends ActionImpl<MyResult> {


### PR DESCRIPTION
Updated the tests to use the new constructor as they all used the default implementation of revealInParent.

https://code.google.com/p/gwt-platform/issues/detail?id=194&colspec=ID%20Stars%20Type%20Status%20Priority%20Component%20Milestone%20Owner%20Summary
