### PR TITLE
PopupViewImpl will trigger onLoad() / onAttach() twice for widgets inside it

### DIFF
--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/PopupViewImpl.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/PopupViewImpl.java
@@ -137,6 +137,10 @@ public abstract class PopupViewImpl extends ViewImpl implements PopupView {
    * needed.
    */
   private void doCenter() {
+    // We can't use Element.center() method as it will show the popup
+    // by default and not only centering it. This is resulting in onAttach()
+    // being called twice when using setInSlot() or addToPopupSlot() in PresenterWidget
+
     // If left/top are set from a previous doCenter() call, and our content
     // has changed, we may get a bogus getOffsetWidth because our new content
     // is wrapping (giving a lower offset width) then it would without the


### PR DESCRIPTION
Changed the implementation of the doCenter() method in PopupViewImpl to reflect the GWT's PopupPanel center() but without forcing the popup to be shown.

In relation to the issue: https://github.com/ArcBees/GWTP/issues/38
