### PR TITLE
Override scope of gin dependency in gwtp-mvp-client

### DIFF
--- a/gwtp-core/gwtp-mvp-client/pom.xml
+++ b/gwtp-core/gwtp-mvp-client/pom.xml
@@ -47,6 +47,7 @@
         <dependency>
             <groupId>com.google.gwt.inject</groupId>
             <artifactId>gin</artifactId>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.google.inject</groupId>


### PR DESCRIPTION
The default provided scope from gwtp-core causes gin to be not a transitive dependency which makes it necessary to declare it again in applications which use gwtp-mvp-client.
