### PR TITLE
Enhancement for HasPopupSlot

### DIFF
--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/HasPopupSlot.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/HasPopupSlot.java
@@ -27,12 +27,11 @@ public interface HasPopupSlot {
      * inherit from {@link PopupView}. The popup will be visible and the
      * corresponding presenter will receive the lifecycle events as needed.
      * <p/>
-     * Contrary to the {@link View#setInSlot(Object, com.google.gwt.user.client.ui.Widget)} method, no
-     * {@link com.gwtplatform.mvp.client.proxy.ResetPresentersEvent} is
-     * fired, so {@link PresenterWidget#onReset()} is not invoked.
+     * Contrary to the {@link View#setInSlot(Object, com.google.gwt.user.client.ui.IsWidget)}
+     * method, no {@link com.gwtplatform.mvp.client.proxy.ResetPresentersEvent}
+     * is fired, so {@link PresenterWidget#onReset()} is not invoked.
      *
-     * @param child The popup child, a {@link PresenterWidget}. Passing {@code null}
-     *              will clear the slot.
+     * @param child The popup child, a {@link PresenterWidget}.
      * @see #addToPopupSlot(PresenterWidget)
      */
     void addToPopupSlot(final PresenterWidget<? extends PopupView> child);
@@ -43,15 +42,24 @@ public interface HasPopupSlot {
      * {@link PopupView}. The popup will be visible and the corresponding
      * presenter will receive the lifecycle events as needed.
      * <p/>
-     * Contrary to the {@link View#setInSlot(Object, com.google.gwt.user.client.ui.Widget)} method, no
-     * {@link com.gwtplatform.mvp.client.proxy.ResetPresentersEvent} is fired,
-     * so {@link PresenterWidget#onReset()} is not invoked.
+     * Contrary to the {@link View#setInSlot(Object, com.google.gwt.user.client.ui.IsWidget)}
+     * method, no {@link com.gwtplatform.mvp.client.proxy.ResetPresentersEvent}
+     * is fired, so {@link PresenterWidget#onReset()} is not invoked.
      *
-     * @param child  The popup child, a {@link PresenterWidget}. Passing {@code null}
-     *               will clear the slot.
+     * @param child  The popup child, a {@link PresenterWidget}.
      * @param center Pass {@code true} to center the popup, otherwise its position
      *               will not be adjusted.
      * @see #addToPopupSlot(PresenterWidget)
      */
     void addToPopupSlot(final PresenterWidget<? extends PopupView> child, boolean center);
+
+    /**
+     * This method removes popup content within the {@link Presenter}. The view
+     * associated with the {@code content}'s presenter must inherit from {@link PopupView}.
+     *
+     * @param child The popup child, a {@link PresenterWidget}, which has
+     *              previously been added using {@link #addToPopupSlot(PresenterWidget)}
+     *              or {@link #addToPopupSlot(PresenterWidget, boolean)}
+     */
+    void removeFromPopupSlot(PresenterWidget<? extends PopupView> child);
 }

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/PresenterWidget.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/PresenterWidget.java
@@ -206,6 +206,23 @@ public abstract class PresenterWidget<V extends View> extends
     }
 
     @Override
+    public void removeFromPopupSlot(PresenterWidget<? extends PopupView> child) {
+        if (child == null) {
+            return;
+        }
+
+        if (popupChildren.contains(child)) {
+            child.getView().hide();
+            if (child.isVisible()) {
+                child.internalHide();
+            }
+            popupChildren.remove(child);
+        }
+
+        child.reparent(null);
+    }
+
+    @Override
     public final void addToSlot(Object slot, PresenterWidget<?> content) {
         if (content == null) {
             return;

--- a/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/PresenterWidgetTest.java
+++ b/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/PresenterWidgetTest.java
@@ -282,6 +282,32 @@ public class PresenterWidgetTest {
         verify(popupContentC.getView(), times(2)).show();
     }
 
+    @Test
+    public void shouldHidePopupWhenPopupPresenterRemoved(
+            PresenterWidgetA presenterWidgetA,
+            PresenterWidgetPopupB popupContentB) {
+
+        // Given
+        presenterWidgetA.internalReveal();
+
+        // When
+        presenterWidgetA.addToPopupSlot(popupContentB);
+
+        // Then
+        verify(popupContentB.getView()).show();
+        verify(popupContentB.getView()).center();
+        assertEquals(1, popupContentB.onRevealMethodCalled);
+        assertTrue(popupContentB.isVisible());
+
+        // and When
+        presenterWidgetA.removeFromPopupSlot(popupContentB);
+
+        // Then
+        verify(popupContentB.getView()).hide();
+        assertEquals(1, popupContentB.onHideMethodCalled);
+        assertFalse(popupContentB.isVisible());
+    }
+
     // TODO Make sure the calls happen in the right order
     // parent then child for onReveal and onReset
     // child then parent for onHide


### PR DESCRIPTION
As a bug fix for [PresenterWidget: passing null to addToPopupSlot() doesn't clear the popup slot](https://code.google.com/p/gwt-platform/issues/detail?id=442) I propose to enhance the interface `HasPopupSlot` with a method `removeFromPopupSlot(PresenterWidget<? extends PopupView> child)`. Thus the interface would have similar methods as the `HasSlots` interface and both implementations could behave in a similar way. Additionally the (IMHO) a little akward behaviour to pass null to an add-method to remove something (which - as stated correctly in the issue - does not work anyway) could be removed.
If there aren't any objections I'd like to give try at the weekend and submit a pull request.
