### PR TITLE
Unlock place manager when async calls fail. 

### DIFF
--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/ProxyPlaceAbstract.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/ProxyPlaceAbstract.java
@@ -239,6 +239,12 @@ public class ProxyPlaceAbstract<P extends Presenter<?, ?>, Proxy_ extends Proxy<
                     }
                 });
             }
+
+            @Override
+            protected void failure(final Throwable caught) {
+                // Unlock place manager to prevent UI "freeze" caused by LockInteractionEvent
+                placeManager.unlock();
+            }
         });
     }
 


### PR DESCRIPTION
Related group posting: https://groups.google.com/forum/#!topic/gwt-platform/3VDf-eHzBi0

There's also another place where 

```
c.g.m.c.proxy.Proxy.getPresenter(NotifyingAsyncCallback)
```

is called: 

```
c.g.m.c.proxy.RevealContentHandler.onRevealContent(RevealContentEvent)
```

Not sure whether there should be the same error handling. 
