### PR TITLE
Add Builder for PlaceRequest, fixes issue 128

### DIFF
--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/PlaceRequest.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/PlaceRequest.java
@@ -79,7 +79,7 @@ public class PlaceRequest {
      * </pre>
      *
      * @param nameToken The name token for the request.
-     * @deprecated Please use {@link com.gwtplatform.mvp.client.proxy.PlaceRequest.Builder#withNameToken(String)}
+     * @deprecated Please use {@link com.gwtplatform.mvp.client.proxy.PlaceRequest.Builder#nameToken(String)}
      * instead
      */
     @Deprecated
@@ -134,8 +134,7 @@ public class PlaceRequest {
      *
      * @param key          The name of the parameter.
      * @param defaultValue The value returned if the parameter is not found.
-     * @return The value of the parameter if found, the {@code defaultValue}
-     *         otherwise.
+     * @return The value of the parameter if found, the {@code defaultValue} otherwise.
      */
     public String getParameter(String key, String defaultValue) {
         String value = null;
@@ -176,8 +175,7 @@ public class PlaceRequest {
      * Checks if this place request has the same name token as the one passed in.
      *
      * @param other The {@link com.gwtplatform.mvp.client.proxy.PlaceRequest} to check against.
-     * @return <code>true</code> if both requests share the same name token.
-     *         <code>false</code> otherwise.
+     * @return <code>true</code> if both requests share the same name token. <code>false</code> otherwise.
      */
     public boolean hasSameNameToken(PlaceRequest other) {
         if (nameToken == null || other.nameToken == null) {
@@ -190,8 +188,7 @@ public class PlaceRequest {
      * Checks if this place request matches the name token passed.
      *
      * @param nameToken The name token to match.
-     * @return <code>true</code> if the request matches. <code>false</code>
-     *         otherwise.
+     * @return <code>true</code> if the request matches. <code>false</code> otherwise.
      */
     public boolean matchesNameToken(String nameToken) {
         if (this.nameToken == null || nameToken == null) {
@@ -208,7 +205,7 @@ public class PlaceRequest {
      * @param name  The new parameter name.
      * @param value The new parameter value.
      * @return The new place request instance.
-     * @deprecated Please use {@link com.gwtplatform.mvp.client.proxy.PlaceRequest.Builder#withParam(String, String)}
+     * @deprecated Please use {@link com.gwtplatform.mvp.client.proxy.PlaceRequest.Builder#with(String, String)}
      * instead
      */
     @Deprecated
@@ -218,9 +215,9 @@ public class PlaceRequest {
         // it reduces unexpected side-effects. Moreover, it lets
         // us instantiate the parameter map only when needed.
         // (See the PlaceRequest constructors.)
-        Builder b = new Builder().withNameToken(nameToken);
-        b.withParams(params);
-        b.withParam(name, value);
+        Builder b = new Builder().nameToken(nameToken);
+        b.with(params);
+        b.with(name, value);
         return b.build();
     }
 
@@ -237,12 +234,12 @@ public class PlaceRequest {
 
         private Map<String, String> params;
 
-        public Builder withNameToken(String nameToken) {
+        public Builder nameToken(String nameToken) {
             this.nameToken = nameToken;
             return this;
         }
 
-        public Builder withParam(String name, String value) {
+        public Builder with(String name, String value) {
             lazyInitializeParamMap();
             if (value != null) {
                 this.params.put(name, value);
@@ -250,7 +247,7 @@ public class PlaceRequest {
             return this;
         }
 
-        public Builder withParams(Map<String, String> params) {
+        public Builder with(Map<String, String> params) {
             lazyInitializeParamMap();
             if (params != null) {
                 this.params.putAll(params);

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/RouteTokenFormatter.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/RouteTokenFormatter.java
@@ -258,7 +258,7 @@ public class RouteTokenFormatter implements TokenFormatter {
 
         match.parameters = parseQueryString(query, match.parameters);
 
-        return new PlaceRequest.Builder().withNameToken(match.route).withParams(match.parameters).build();
+        return new PlaceRequest.Builder().nameToken(match.route).with(match.parameters).build();
     }
 
     @Override

--- a/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/proxy/PlaceRequestTest.java
+++ b/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/proxy/PlaceRequestTest.java
@@ -32,7 +32,6 @@ import static org.junit.Assert.assertNull;
  * {@link com.gwtplatform.mvp.client.proxy.PlaceRequest.Builder} tests.
  */
 public class PlaceRequestTest {
-
     @Test
     public void shouldBuildEmptyRequest() {
         // when
@@ -48,8 +47,8 @@ public class PlaceRequestTest {
     @Test
     public void shouldBuildRequestWithSeveralParameters() {
         // when
-        PlaceRequest request = new PlaceRequest.Builder().withNameToken("nameToken").withParam("name1", "value1")
-                .withParam("name2", "value2").build();
+        PlaceRequest request = new PlaceRequest.Builder().nameToken("nameToken").with("name1", "value1")
+                .with("name2", "value2").build();
 
         // then
         assertNotNull(request);
@@ -66,8 +65,8 @@ public class PlaceRequestTest {
         existingParameters.put("name2", "value2");
 
         // when
-        PlaceRequest request = new PlaceRequest.Builder().withNameToken("nameToken").withParams(existingParameters)
-                .withParam("name3", "value3").build();
+        PlaceRequest request = new PlaceRequest.Builder().nameToken("nameToken").with(existingParameters)
+                .with("name3", "value3").build();
 
         // then
         assertNotNull(request);


### PR DESCRIPTION
New internal Builder class for PlaceRequest; most constructors as well
as with method have been deprecated in favor of new builder methods.
Package visible constructor has been made private and its usage in
RouteTokenFormatter adapted to usage of builder.
