### PR TITLE
Added UMLGraph to javadocs.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -462,12 +462,12 @@
                     </header>
                     <doclet>org.umlgraph.doclet.UmlGraphDoc</doclet>
                     <docletArtifact>
-                      <groupId>org.umlgraph</groupId>
-                      <artifactId>umlgraph</artifactId>
-                      <version>5.6.6</version>
+                        <groupId>org.umlgraph</groupId>
+                        <artifactId>umlgraph</artifactId>
+                        <version>5.6.6</version>
                     </docletArtifact>
                     <additionalparam>
-                      -horizontal
+                        -horizontal
                     </additionalparam>
                 </configuration>
                 <executions>


### PR DESCRIPTION
What do you think of using UmlGraph in the javadocs? If you don't like it I can remove them. 

![screen shot 2013-06-12 at 6 36 06 pm](https://f.cloud.github.com/assets/1326504/646389/9c887bf0-d3ca-11e2-8135-69db2d2228f9.png)

Few examples:
http://arcbees.github.io/GWTP/javadoc/apidocs/com/gwtplatform/dispatch/shared/Action.html
http://arcbees.github.io/GWTP/javadoc/apidocs/com/gwtplatform/mvp/client/gin/AbstractPresenterModule.html
http://arcbees.github.io/GWTP/javadoc/apidocs/com/gwtplatform/dispatch/annotation/processor/GenProcessor.html

Thoughts?
