### PR TITLE
Avoid that the RootPresenter.unlockScreen()  throws a javascript exception

### DIFF
--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/RootPresenter.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/RootPresenter.java
@@ -109,8 +109,9 @@ public class RootPresenter extends PresenterWidget<RootPresenter.RootView>
         }
 
         public void unlockScreen() {
-            ensureGlass();
-            Document.get().getBody().removeChild(glass);
+            if (glass != null) {
+                glass.removeFromParent();
+            }
         }
 
         public void ensureGlass() {
@@ -134,7 +135,7 @@ public class RootPresenter extends PresenterWidget<RootPresenter.RootView>
 
     /**
      * Creates a proxy class for a presenter that can contain tabs.
-     * 
+     *
      * @param eventBus
      *            The event bus.
      */


### PR DESCRIPTION
If the screen is not previously locked, call of the unlockScreen method throws an javascript exception ElementNotFound
