### PR TITLE
The doCenter method doesn't center correctly the popup when the popup is hidden

### DIFF
--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/PopupViewImpl.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/PopupViewImpl.java
@@ -152,7 +152,7 @@ public abstract class PopupViewImpl extends ViewImpl implements PopupView {
         elem.getStyle().clearTop();
 
         // the popup should be added to the dom in order to get correct values for offsetWidth/offsetHeight
-        if (!isShowing){
+        if (!isShowing) {
             popup.setVisible(false);
             popup.show();
         }


### PR DESCRIPTION
The doCenter method is called twice when the popup presenter is revealed. The first time the method is called the popupPanel is hidden and the offsetWidth/ offsetHeight returns 0. The popuppanel is not correctly centered.

When the second call is done (in a deferred command) the popup is visible and so is correctly centered. But it looks like the popup jumps from the bottom right corner to the center. Furthermore if the developer is trying to align another widget with the popup (a tooltip for example) during the on reveal, the elements is misplaced.
