### PR TITLE
Spring GWTP-Dispatch secure action simplify configuration, by providing a default value for cookieName.

### DIFF
--- a/gwtp-core/gwtp-dispatch-server-spring/src/main/java/com/gwtplatform/dispatch/server/spring/DispatchModule.java
+++ b/gwtp-core/gwtp-dispatch-server-spring/src/main/java/com/gwtplatform/dispatch/server/spring/DispatchModule.java
@@ -21,6 +21,7 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 
 import com.gwtplatform.dispatch.server.Dispatch;
 import com.gwtplatform.dispatch.server.actionhandlervalidator.ActionHandlerValidatorRegistry;
@@ -77,6 +78,11 @@ public class DispatchModule {
         }
 
         return instance;
+    }
+
+    @Bean
+    public static PropertySourcesPlaceholderConfigurer propertySourcesPlaceholderConfigurer() {
+        return new PropertySourcesPlaceholderConfigurer();
     }
 
     @Bean

--- a/gwtp-core/gwtp-dispatch-server-spring/src/main/java/com/gwtplatform/dispatch/server/spring/DispatchServiceImpl.java
+++ b/gwtp-core/gwtp-dispatch-server-spring/src/main/java/com/gwtplatform/dispatch/server/spring/DispatchServiceImpl.java
@@ -25,6 +25,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.HttpRequestHandler;
 import org.springframework.web.context.ServletContextAware;
@@ -41,7 +42,7 @@ public class DispatchServiceImpl extends AbstractDispatchServiceImpl implements 
 
     private static final long serialVersionUID = 136176741488585959L;
 
-    @Autowired(required = false)
+    @Value("${securityCookieName:JSESSIONID}")
     protected String securityCookieName;
 
     private ServletContext servletContext;
@@ -55,10 +56,6 @@ public class DispatchServiceImpl extends AbstractDispatchServiceImpl implements 
     @Override
     public String getSecurityCookieName() {
         return securityCookieName;
-    }
-
-    public void setSecurityCookieName(String securityCookieName) {
-        this.securityCookieName = securityCookieName;
     }
 
     @Override


### PR DESCRIPTION
Offer a default name for securityCookie when there any name defined on Spring scanned properties files.

The default name is **JSESSIONID**, which is the one used in most cases, otherwise the user need to override that by defining it on his property file, the key of the property is **securityCookieName**.
