### PR TITLE
Added jax-rs to gin exceptions.

### DIFF
--- a/gwtp-core/gwtp-dispatch-rest/src/main/resources/com/gwtplatform/dispatch/DispatchRest.gwt.xml
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/resources/com/gwtplatform/dispatch/DispatchRest.gwt.xml
@@ -18,6 +18,8 @@
 
     <entry-point class='com.gwtplatform.dispatch.client.rest.RestDispatcherController'/>
 
+    <extend-configuration-property name="gin.classloading.exceptedPackages" value="javax.ws.rs"/>
+
     <extend-configuration-property name="gin.ginjector.modules"
             value="com.gwtplatform.dispatch.client.rest.RestGinModule"/>
 


### PR DESCRIPTION
This removes the warning thrown by gin at compile time for jax-rs annotations not being available in gwt

@christiangoudreau @meriouma @spg 
