### PR TITLE
Glass fix for IE

### DIFF
--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/RootPresenter.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/RootPresenter.java
@@ -136,8 +136,8 @@ public class RootPresenter extends PresenterWidget<RootPresenter.RootView>
                 style.setRight(0, Unit.PX);
                 style.setBottom(0, Unit.PX);
                 style.setZIndex(2147483647); // Maximum z-index
-	            style.setBackgroundColor("#FFFFFF");
-	            style.setOpacity(0);
+                style.setBackgroundColor("#FFFFFF");
+                style.setOpacity(0);
             }
         }
     }


### PR DESCRIPTION
In IE glass allows to click button behind it. This patch solves this problem.
