### PR TITLE
Some fixes for formfactor

### DIFF
--- a/gwtp-core/gwtp-mvp-client/src/main/resources/com/gwtplatform/mvp/rebind/linker/formFactor.js
+++ b/gwtp-core/gwtp-mvp-client/src/main/resources/com/gwtplatform/mvp/rebind/linker/formFactor.js
@@ -25,7 +25,7 @@ function findFormFactorFromQuery(href, propertyName) {
 function findFormFactorFromUserAgent(userAgent) {
     var mobileRe = /(iphone|ipod|mobile)/i;
     var notMobileRe = /silk/i;
-    var tabletRe = /(android|ipad|tablet|kindle|silk)/i;
+    var tabletRe = /(android|ipad|tablet|kindle)/i;
 
     if (userAgent.match(mobileRe) && !userAgent.match(notMobileRe)) {
         return "mobile";

--- a/gwtp-core/gwtp-mvp-client/src/test/javascript/formFactor.coffee
+++ b/gwtp-core/gwtp-mvp-client/src/test/javascript/formFactor.coffee
@@ -19,9 +19,6 @@ describe 'finding from user agent', ->
     it 'should be tablet when userAgent is ipad', ->
       expect(findFormFactorFromUserAgent('ipad')).toBe 'tablet'
 
-    it 'should be tablet when userAgent is silk', ->
-      expect(findFormFactorFromUserAgent('silk')).toBe 'tablet'
-
   describe 'for a desktop computer', ->
     it 'should be desktop when userAgent is desktop', ->
       expect(findFormFactorFromUserAgent('desktop')).toBe 'desktop'


### PR DESCRIPTION
My original code which tried to check windows 8 desktop / modern mode didn't work so I removed it.

notMobileRe should be silk not kindle so I fixed it.

All ua's that match (silk) also match (android|kindle) so silk in tabletRe was superfluous and has been removed.

Updated formfactor tests to reflect new changes.
