### PR TITLE
add OSGI support for server side gwtp libraries

### DIFF
--- a/gwtp-core/gwtp-dispatch-common-shared/pom.xml
+++ b/gwtp-core/gwtp-dispatch-common-shared/pom.xml
@@ -10,6 +10,7 @@
     </parent>
 
     <artifactId>gwtp-dispatch-common-shared</artifactId>
+    <packaging>bundle</packaging>
 
     <dependencies>
         <!-- Needed for @BindingAnnotation in SecurityCookie, can safely be ignored when using Spring -->
@@ -37,5 +38,22 @@
                 </includes>
             </resource>
         </resources>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Export-Package>
+                            com.gwtplatform.dispatch.shared;${project.artifactId}=split;mandatory:=${project.artifactId}
+                        </Export-Package>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Import-Package>
+                            *;resolution:=optional
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
 </project>

--- a/gwtp-core/gwtp-dispatch-rpc-server-guice/pom.xml
+++ b/gwtp-core/gwtp-dispatch-rpc-server-guice/pom.xml
@@ -10,6 +10,7 @@
 
     <artifactId>gwtp-dispatch-rpc-server-guice</artifactId>
     <name>GWTP RPC-Dispatch Server, Guice implementation</name>
+    <packaging>bundle</packaging>
 
     <dependencies>
         <dependency>
@@ -40,4 +41,25 @@
             <artifactId>jukito</artifactId>
         </dependency>
     </dependencies>
+    
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Export-Package>
+                            com.gwtplatform.dispatch.rpc.server.guice.*,
+                            com.gwtplatform.dispatch.server.guice.*
+                        </Export-Package>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Import-Package>
+                            *;resolution:=optional
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/gwtp-core/gwtp-dispatch-rpc-server-spring/pom.xml
+++ b/gwtp-core/gwtp-dispatch-rpc-server-spring/pom.xml
@@ -10,6 +10,7 @@
 
     <artifactId>gwtp-dispatch-rpc-server-spring</artifactId>
     <name>GWTP RPC-Dispatch Server, Spring implementation</name>
+    <packaging>bundle</packaging>
 
     <dependencies>
         <dependency>
@@ -66,4 +67,25 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Export-Package>
+                            com.gwtplatform.dispatch.rpc.server.spring.*,
+                            com.gwtplatform.dispatch.server.spring.*
+                        </Export-Package>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Import-Package>
+                            *;resolution:=optional
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/gwtp-core/gwtp-dispatch-rpc-server/pom.xml
+++ b/gwtp-core/gwtp-dispatch-rpc-server/pom.xml
@@ -10,6 +10,7 @@
 
     <artifactId>gwtp-dispatch-rpc-server</artifactId>
     <name>GWTP RPC-Dispatch Server Common</name>
+    <packaging>bundle</packaging>
 
     <dependencies>
         <dependency>
@@ -25,4 +26,25 @@
             <artifactId>gwt-user</artifactId>
         </dependency>
     </dependencies>
+    
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Export-Package>
+                            com.gwtplatform.dispatch.rpc.server.*,
+                            com.gwtplatform.dispatch.server.*
+                        </Export-Package>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Import-Package>
+                            *;resolution:=optional
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/gwtp-core/gwtp-dispatch-rpc-shared/pom.xml
+++ b/gwtp-core/gwtp-dispatch-rpc-shared/pom.xml
@@ -10,11 +10,12 @@
 
     <artifactId>gwtp-dispatch-rpc-shared</artifactId>
     <name>GWTP RPC-Dispatch Shared</name>
-
+    <packaging>bundle</packaging>
+    
     <build>
         <resources>
             <!-- Bundle sources with the jar, so they are visible to GWT's
-                compiler -->
+            compiler -->
             <resource>
                 <directory>src/main/java</directory>
                 <includes>
@@ -22,7 +23,7 @@
                 </includes>
             </resource>
             <!-- Bundle module descriptor with the jar, so it is visible
-                to GWT's compiler -->
+            to GWT's compiler -->
             <resource>
                 <directory>src/main/resources</directory>
                 <includes>
@@ -39,6 +40,23 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <proc>none</proc>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Export-Package>
+                            com.gwtplatform.dispatch.rpc.shared,
+                            com.gwtplatform.dispatch.shared
+                        </Export-Package>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Require-Bundle>gwtp-dispatch-common-shared;visibility:=reexport</Require-Bundle>
+                        <Import-Package>
+                            *;resolution:=optional
+                        </Import-Package>
+                    </instructions>
                 </configuration>
             </plugin>
         </plugins>

--- a/gwtp-core/gwtp-mvp-shared/pom.xml
+++ b/gwtp-core/gwtp-mvp-shared/pom.xml
@@ -10,6 +10,7 @@
 
     <artifactId>gwtp-mvp-shared</artifactId>
     <name>GWTP MVP shared</name>
+    <packaging>bundle</packaging>
 
     <build>
         <resources>
@@ -23,6 +24,23 @@
                 <directory>src/main/resources</directory>
             </resource>
         </resources>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Export-Package>
+                            com.gwtplatform.mvp.shared.proxy
+                        </Export-Package>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Import-Package>
+                            *;resolution:=optional
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -242,6 +242,7 @@
         <maven-dependency-plugin.version>2.8</maven-dependency-plugin.version>
         <maven-site-plugin.version>3.3</maven-site-plugin.version>
         <jasmine-maven-plugin.version>1.3.1.4</jasmine-maven-plugin.version>
+        <maven-bundle-plugin.version>2.4.0</maven-bundle-plugin.version>
 
         <!-- Client -->
         <gwt.version>2.6.0</gwt.version>
@@ -427,11 +428,18 @@
                     <artifactId>jasmine-maven-plugin</artifactId>
                     <version>${jasmine-maven-plugin.version}</version>
                 </plugin>
+                
+                <plugin>
+                    <groupId>org.apache.felix</groupId>
+                    <artifactId>maven-bundle-plugin</artifactId>
+                    <version>${maven-bundle-plugin.version}</version>
+                    <extensions>true</extensions>
+                </plugin>
             </plugins>
         </pluginManagement>
 
         <!-- Plugins to be inherited by sub-projects. Note that definitions and configurations of the following plugins in
-            a sub module, will override the top level parent pom's definition -->
+        a sub module, will override the top level parent pom's definition -->
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This is proposal for OSGi-fication of GWTP server side libraries. 
It needs to be tested. Actually, I don't know which API should be exported and which are private.
There is also one OSGi like dirty thing in gwtp. Modules gwtp-dispatch-common-shared and gwtp-dispatch-rpc-shared exports same package (com.gwtplatform.dispatch.shared) whis is not good, but it works using split OSGi features. I tested it on karaf 3.0.1

Example of karaf feature.xml:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<features name="karaf-features-1.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xmlns="http://karaf.apache.org/xmlns/features/v1.0.0"
          xsi:schemaLocation="http://karaf.apache.org/xmlns/features/v1.0.0 http://karaf.apache.org/xmlns/features/v1.0.0">
    <feature name="gwt-server" version="2.6.1">
        <!--<bundle>wrap:mvn:javax.validation/validation-api/1.0.0.GA</bundle>-->
        <bundle>wrap:mvn:com.google.gwt/gwt-servlet/2.6.1</bundle>
        <bundle>mvn:com.google.inject/guice/3.0</bundle><!-- https://code.google.com/p/google-guice/wiki/OSGi gwtp -->
        <bundle>mvn:com.google.inject.extensions/guice-servlet/3.0</bundle>
        <bundle>mvn:com.google.inject.extensions/guice-assistedinject/3.0</bundle>
        <bundle>mvn:javax.inject/com.springsource.javax.inject/1.0.0</bundle>
        <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.aopalliance/1.0_6</bundle>
    </feature>
    <feature name="gwtp-server" version="1.3">
        <feature version="2.6.1">gwt-server</feature>
        <bundle>mvn:com.gwtplatform/gwtp-dispatch-rpc-server/1.3-SNAPSHOT</bundle>
        <bundle>mvn:com.gwtplatform/gwtp-dispatch-rpc-server-guice/1.3-SNAPSHOT</bundle>
        <bundle>mvn:com.gwtplatform/gwtp-dispatch-rpc-shared/1.3-SNAPSHOT</bundle>
        <bundle>mvn:com.gwtplatform/gwtp-dispatch-common-shared/1.3-SNAPSHOT</bundle>
        <bundle>mvn:com.gwtplatform/gwtp-mvp-shared/1.3-SNAPSHOT</bundle>
    </feature>
</features>
```
