### PR TITLE
Add log message when uiHandlers is null

### DIFF
--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/ViewWithUiHandlers.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/ViewWithUiHandlers.java
@@ -29,7 +29,7 @@ import java.util.logging.Logger;
  * @param <C> Your {@link UiHandlers} interface type.
  */
 public abstract class ViewWithUiHandlers<C extends UiHandlers> extends ViewImpl
- implements HasUiHandlers<C> {
+        implements HasUiHandlers<C> {
 
     private static final Logger logger = Logger.getLogger(ViewWithUiHandlers.class.getName());
     private C uiHandlers;


### PR DESCRIPTION
Every now and then I'll call getUiHandlers() from my views constructor and it always takes me a while to work out what's gone wrong.

I'd prefer to throw a RuntimeException instead of just the log message since I don't think anyone ever intends to call getUiHandlers before setting it but a log message will be helpful on it's own.  
