### PR TITLE
add registerVisibleHandler(HandlerRegistration) for PresenterWidget (patch)

### DIFF
--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/PresenterWidget.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/PresenterWidget.java
@@ -442,7 +442,7 @@ public abstract class PresenterWidget<V extends View> extends
 
    /**
      * Registers a handler so that it is automatically removed when
-     * {@link #unHide()} is called. This provides an easy way to track event
+     * {@link #onHide()} is called. This provides an easy way to track event
      * handler registrations.
      *
      * @param handlerRegistration The registration of handler to track.


### PR DESCRIPTION
Hi,

it would be nice if `PresenterWidget` would have a method 

```
registerVisibleHandler(HandlerRegistration)
```

There is already a similar functionality (`addVisibleHandler`), which requires an event type as argument. My suggested method would take any previously created `HandlerRegistration`. A similar method `addRegisteredHandler` is already presenter, which removes the handlers in the `onUnbind` method. However, it might be more efficient to remove a handler already in the `onHide`.

The functionality is already there in the code using the field `visibleHandlerRegistrations` of the `PresenterWidget`. It is just not accessible on a protected/public level. 

Thanks
Daniel
