### PR TITLE
Explicitly set empty request body to null

### DIFF
--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/DefaultRestRequestBuilderFactory.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/DefaultRestRequestBuilderFactory.java
@@ -193,6 +193,11 @@ public class DefaultRestRequestBuilderFactory implements RestRequestBuilderFacto
             requestBuilder.setRequestData(buildQueryString(action.getFormParams()));
         } else if (action.hasBodyParam()) {
             requestBuilder.setRequestData(getSerializedValue(action, action.getBodyParam()));
+        } else {
+            // Fixes an issue for all IE versions (IE 11 is the latest at this time). If request data is not explicitly
+            // set to 'null', the JS 'undefined' will be sent as the request body on IE. Other browsers don't send
+            // undefined bodies.
+            requestBuilder.setRequestData(null);
         }
     }
 

--- a/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/DefaultRestRequestBuilderFactoryTest.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/DefaultRestRequestBuilderFactoryTest.java
@@ -45,11 +45,13 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.endsWith;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isNull;
 import static org.mockito.Matchers.startsWith;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
+import static com.gwtplatform.dispatch.rest.shared.HttpMethod.DELETE;
 import static com.gwtplatform.dispatch.rest.shared.HttpMethod.GET;
 import static com.gwtplatform.dispatch.rest.shared.HttpMethod.POST;
 import static com.gwtplatform.dispatch.rest.shared.MetadataType.BODY_TYPE;
@@ -129,6 +131,18 @@ public class DefaultRestRequestBuilderFactoryTest {
         given(urlUtils.encodeQueryString(DECODED_VALUE_1)).willReturn(ENCODED_VALUE_1);
         given(urlUtils.encodeQueryString(DECODED_VALUE_2)).willReturn(ENCODED_VALUE_2);
         given(urlUtils.encodeQueryString(DECODED_VALUE_3)).willReturn(ENCODED_VALUE_3);
+    }
+
+    @Test
+    public void build_noFormParamsNoBody_setsExplicitNullAsRequestData() throws ActionException {
+        // Given
+        RestAction<Void> action = new UnsecuredRestAction(DELETE, RELATIVE_PATH);
+
+        // When
+        factory.build(action, SECURITY_TOKEN);
+
+        // Then
+        verify(requestBuilder).setRequestData(isNull(String.class));
     }
 
     @Test
@@ -216,14 +230,14 @@ public class DefaultRestRequestBuilderFactoryTest {
 
         // Then
         String expectedRequestData = "Key1=" + ENCODED_VALUE_1
-                                     + "&Key2=" + ENCODED_VALUE_2
-                                     + "&Key3=" + ENCODED_VALUE_3;
+                + "&Key2=" + ENCODED_VALUE_2
+                + "&Key3=" + ENCODED_VALUE_3;
         verify(requestBuilder).setRequestData(eq(expectedRequestData));
     }
 
     @Test
     public void requestDataShouldBeSerializedStringWhenActionHasBody(Serialization serialization,
-                                                                     ActionMetadataProvider metadataProvider)
+            ActionMetadataProvider metadataProvider)
             throws ActionException {
         // Given
         Object unserializedObject = new Object();


### PR DESCRIPTION
Fixes #584 

I tested the fix on IE11 (it works). If anyone has access to older versions of IE (I don't have one of those IE vm setup), you can try to delete something on http://gwtp-carstore.appspot.com (credentials are admin/querty). Thanks!
