### PR TITLE
Make PlaceManagerImpl use Historian instead of History

### DIFF
--- a/gwtp-core/gwtp-mvp-client/src/main/resources/com/gwtplatform/mvp/Mvp.gwt.xml
+++ b/gwtp-core/gwtp-mvp-client/src/main/resources/com/gwtplatform/mvp/Mvp.gwt.xml
@@ -8,6 +8,7 @@
     <!-- Inherit shared modules -->
     <inherits name='com.gwtplatform.common.ClientsCommon'/>
     <inherits name='com.gwtplatform.mvp.MvpShared'/>
+    <inherits name='com.google.gwt.place.Place'/>
 
     <generate-with class="com.gwtplatform.mvp.rebind.ApplicationControllerGenerator">
         <when-type-is class="com.gwtplatform.mvp.client.ApplicationController"/>


### PR DESCRIPTION
Uses `Historian` interface in `PlaceManagerImpl` instead of `History`.

It will be impossible to replace the GWT History implementation in 2.7.  By switching to Historian GWTP users can replace the `DefaultHistorian` implementation with another eg. to support PushState.

This does have a minor impact on behavior.  Before when you called `revealCurrentPlace()` History would refire its state.  Now it won't.
