### PR TITLE
Use a custom provider to get the presenter in generated proxies.

### DIFF
--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/annotations/CustomProvider.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/annotations/CustomProvider.java
@@ -34,6 +34,7 @@ import com.gwtplatform.common.client.IndirectProvider;
  * Here is an example use of {@code CustomProvider}:
  * <p/>
  * <pre>
+ * &#064;ProxyCodeSplit
  * &#064;CustomProvider(SecurityContextProvider.class)
  * public interface MyProxy extends ProxyPlace&lt;MyPresenter&gt; {
  * }

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/annotations/CustomProvider.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/annotations/CustomProvider.java
@@ -55,8 +55,6 @@ import com.gwtplatform.common.client.IndirectProvider;
  *     }
  * }
  * </pre>
- *
- * @author Harald Pehl
  */
 @Target(ElementType.TYPE)
 public @interface CustomProvider {

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/annotations/CustomProvider.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/annotations/CustomProvider.java
@@ -34,7 +34,6 @@ import com.gwtplatform.common.client.IndirectProvider;
  * Here is an example use of {@code CustomProvider}:
  * <p/>
  * <pre>
- * &#064;ProxyCodeSplit
  * &#064;CustomProvider(SecurityContextProvider.class)
  * public interface MyProxy extends ProxyPlace&lt;MyPresenter&gt; {
  * }

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/annotations/CustomProvider.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/annotations/CustomProvider.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2011 ArcBees Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.gwtplatform.mvp.client.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+import com.gwtplatform.common.client.IndirectProvider;
+
+/**
+ * Use this annotation with a {@link com.gwtplatform.mvp.client.proxy.Proxy} to specify a custom
+ * {@linkplain com.gwtplatform.common.client.IndirectProvider provider} which is used to load the
+ * presenter behind the proxy. Using a custom provider enables you to add steps which should happen
+ * <b>before</b> the presenter is loaded, instantiated and processed by GIN.
+ * <p/>
+ * The class implementing {@code IndirectProvider} must provide a constructor which takes the
+ * original provider as the single argument. For presenters which use {@code @ProxyStandard}
+ * this is {@code com.google.inject.Provider&lt;T&gt;}; for presenters which use {@code @ProxyCodeSplit}
+ * or {@code @ProxyCodeSplitBundle} this is {@code com.google.gwt.inject.client.AsyncProvider&lt;T&gt;}
+ * <p/>
+ * Here is an example use of {@code CustomProvider}:
+ * <p/>
+ * <pre>
+ * &#064;ProxyCodeSplit
+ * &#064;CustomProvider(SecurityContextProvider.class)
+ * public interface MyProxy extends ProxyPlace&lt;MyPresenter&gt; {
+ * }
+ *
+ * ...
+ *
+ * public class SecurityContextProvider implements IndirectProvider&lt;MyPresenter&gt; {
+ *     private final AsyncProvider&lt;MyPresenter&gt; provider;
+ *
+ *     public SecurityContextProvider(AsyncProvider&lt;MyPresenter&gt; provider) {
+ *         this.provider = provider;
+ *     }
+ *
+ *     &#064;Override
+ *     public void get(AsyncCallback&lt;MyPresenter&gt; callback) {
+ *         // Place your custom logic here, e.g. fetch data from the server.
+ *         // If everything is ready, call
+ *         provider.get(callback);
+ *     }
+ * }
+ * </pre>
+ *
+ * @author Harald Pehl
+ */
+@Target(ElementType.TYPE)
+public @interface CustomProvider {
+    Class<? extends IndirectProvider> value();
+}

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/PresenterInspector.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/PresenterInspector.java
@@ -26,8 +26,15 @@ import com.google.gwt.core.ext.typeinfo.JField;
 import com.google.gwt.core.ext.typeinfo.JMethod;
 import com.google.gwt.core.ext.typeinfo.TypeOracle;
 import com.google.gwt.user.rebind.SourceWriter;
-import com.gwtplatform.mvp.client.annotations.*;
+import com.gwtplatform.mvp.client.annotations.ContentSlot;
+import com.gwtplatform.mvp.client.annotations.CustomProvider;
+import com.gwtplatform.mvp.client.annotations.ProxyCodeSplit;
+import com.gwtplatform.mvp.client.annotations.ProxyCodeSplitBundle;
 import com.gwtplatform.mvp.client.annotations.ProxyCodeSplitBundle.NoOpProviderBundle;
+import com.gwtplatform.mvp.client.annotations.ProxyEvent;
+import com.gwtplatform.mvp.client.annotations.ProxyStandard;
+import com.gwtplatform.mvp.client.annotations.TabInfo;
+import com.gwtplatform.mvp.client.annotations.TitleFunction;
 
 /**
  * A class used to inspect the presenter, the methods and inner interfaces it contains.
@@ -215,8 +222,8 @@ public class PresenterInspector {
                         + ">( ginjector." + getPresenterMethodName + "() );");
             } else {
                 assert proxyCodeSplitBundleAnnotation != null;
-                writer.print("presenter = new CodeSplitBundleProvider<"
-                        + presenterClassName + ", " + bundleClassName + ">(ginjector." + getPresenterMethodName + "(), ");
+                writer.print("presenter = new CodeSplitBundleProvider<" + presenterClassName
+                        + ", " + bundleClassName + ">(ginjector." + getPresenterMethodName + "(), ");
                 if (ginjectorInspector.isGenerated()) {
                     writer.print(bundleClassName + "." + presenterClass.getSimpleSourceName().toUpperCase() + ");");
                 } else {

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/PresenterInspector.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/PresenterInspector.java
@@ -212,23 +212,20 @@ public class PresenterInspector {
             JClassType customProvider = oracle.findType(customProviderAnnotation.value().getName());
             writer.println("presenter = new " + customProvider.getQualifiedSourceName() + "<" + presenterClassName
                         + ">( ginjector." + getPresenterMethodName + "() );");
-
+        } else if (proxyStandardAnnotation != null) {
+            writer.println("presenter = new StandardProvider<" + presenterClassName
+                    + ">( ginjector." + getPresenterMethodName + "() );");
+        } else if (proxyCodeSplitAnnotation != null) {
+            writer.println("presenter = new CodeSplitProvider<" + presenterClassName
+                    + ">( ginjector." + getPresenterMethodName + "() );");
         } else {
-            if (proxyStandardAnnotation != null) {
-                writer.println("presenter = new StandardProvider<" + presenterClassName
-                        + ">( ginjector." + getPresenterMethodName + "() );");
-            } else if (proxyCodeSplitAnnotation != null) {
-                writer.println("presenter = new CodeSplitProvider<" + presenterClassName
-                        + ">( ginjector." + getPresenterMethodName + "() );");
+            assert proxyCodeSplitBundleAnnotation != null;
+            writer.print("presenter = new CodeSplitBundleProvider<" + presenterClassName
+                    + ", " + bundleClassName + ">(ginjector." + getPresenterMethodName + "(), ");
+            if (ginjectorInspector.isGenerated()) {
+                writer.print(bundleClassName + "." + presenterClass.getSimpleSourceName().toUpperCase() + ");");
             } else {
-                assert proxyCodeSplitBundleAnnotation != null;
-                writer.print("presenter = new CodeSplitBundleProvider<" + presenterClassName
-                        + ", " + bundleClassName + ">(ginjector." + getPresenterMethodName + "(), ");
-                if (ginjectorInspector.isGenerated()) {
-                    writer.print(bundleClassName + "." + presenterClass.getSimpleSourceName().toUpperCase() + ");");
-                } else {
-                    writer.print(proxyCodeSplitBundleAnnotation.id() + ");");
-                }
+                writer.print(proxyCodeSplitBundleAnnotation.id() + ");");
             }
         }
     }
@@ -341,6 +338,9 @@ public class PresenterInspector {
             nbNonNullTags++;
         }
         if (proxyCodeSplitBundleAnnotation != null) {
+            nbNonNullTags++;
+        }
+        if (customProviderAnnotation != null) {
             nbNonNullTags++;
         }
 

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/PresenterInspector.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/PresenterInspector.java
@@ -210,8 +210,9 @@ public class PresenterInspector {
 
         if (customProviderAnnotation != null) {
             JClassType customProvider = oracle.findType(customProviderAnnotation.value().getName());
-            writer.println("presenter = new " + customProvider.getQualifiedSourceName() + "<" + presenterClassName
-                        + ">( ginjector." + getPresenterMethodName + "() );");
+            writer.println("presenter = new " + customProvider.getQualifiedSourceName()
+                    + "( ginjector." + getPresenterMethodName + "() );");
+
         } else if (proxyStandardAnnotation != null) {
             writer.println("presenter = new StandardProvider<" + presenterClassName
                     + ">( ginjector." + getPresenterMethodName + "() );");
@@ -338,9 +339,6 @@ public class PresenterInspector {
             nbNonNullTags++;
         }
         if (proxyCodeSplitBundleAnnotation != null) {
-            nbNonNullTags++;
-        }
-        if (customProviderAnnotation != null) {
             nbNonNullTags++;
         }
 


### PR DESCRIPTION
This is a proposal to customize the way how the presenter is loaded by the proxy. The motivation therefore are situations where you need to execute code or fetch data from the server **before** the actual presenter lifecycle starts. That is to say it's a proposal to prepend the current presenter lifecyle. 

Presenters are loaded from genrated proxy classes using an instance of `IndirectProvider<T>`. The concrete instance depends on the annotation used with the proxy interface:

- `@ProxyStandard` &rarr; `StandardProvider<P>`
- `@ProxyCodeSplit` &rarr; `CodeSplitProvider<P>`
- `@ProxyCodeSplitBundle` &rarr; `CodeSplitBundleProvider<P>`

This PR adds the annotation `@CustomProvider` to specify a custom provider. Just like the existing indirect providers, custom providers should specify a constructor which receives the GIN provider as specifed by the Ginjector. I hope the following code snippet makes it more obvious:

```java
@ProxyCodeSplit
@CustomProvider(SecurityContextProvider.class)
public interface MyProxy extends ProxyPlace<AdminPresenter> {}

...

public class SecurityContextProvider implements IndirectProvider<AdminPresenter> {
    private final AsyncProvider<AdminPresenter> provider;

    public SecurityContextProvider(AsyncProvider<AdminPresenter> provider) {
        this.provider = provider;
    }

    @Override
    public void get(AsyncCallback<AdminPresenter> callback) {
        // Fetch data from the server which needs to be at hand 
        // _before_ the presenter is loaded.
        provider.get(callback);
    }
}
```

See also the GWTP post at [1] 

[1] https://groups.google.com/forum/#!topic/gwt-platform/jAxPQQQ3Jtk