### PR TITLE
finalize ManualRevealCallback class

### DIFF
--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/ManualRevealCallback.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/ManualRevealCallback.java
@@ -30,7 +30,7 @@ import com.gwtplatform.mvp.client.Presenter;
  *
  * @param <T> The type of the return value, see {@link AsyncCallback}.
  */
-public class ManualRevealCallback<T> implements AsyncCallback<T> {
+public final class ManualRevealCallback<T> implements AsyncCallback<T> {
 
     private final Presenter<?, ? extends ProxyPlace<?>> presenter;
     private final AsyncCallback<T> callback;


### PR DESCRIPTION
I'm an idiot but I often start off with an AsyncCallback and then convert it to a ManualReveal callback and end up with:

```
new ManualRevealCallback<T>(aPresenter) {
    @Override
    public void onFailure(Throwable caught) {

     }

     @Override
     public void onSuccess(T result) {
          //do some work and then wonder why the presenter is never revealed.
     }
}
```

This prevents the above by preventing ManualRevealCallback from being subclassed.
