### PR TITLE
Update gwt-jackson to 0.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -247,7 +247,7 @@
         <gwt.version>2.7.0</gwt.version>
         <!-- when you update the gwt version please also update the dtds in all gwt.xml files -->
         <gin.version>2.1.2</gin.version>
-        <gwt-jackson.version>0.6.1</gwt-jackson.version>
+        <gwt-jackson.version>0.8.0</gwt-jackson.version>
 
         <!-- Server -->
         <jax-rs.version>1.1.1</jax-rs.version>


### PR DESCRIPTION
I just released the 0.8.0 version. 

Since the 0.6.1 version, there has been some changes. The largest one is probably the support for Object and Serializable type. And with it, the support for new annotations like @JsonAnyGetter and @JsonAnySetter. To avoid the generation of serializer/deserializer for all Objects, I went the opposite way of RPC. By default, only the configured types (in [AbstractConfiguration](https://github.com/nmorel/gwt-jackson/blob/master/gwt-jackson/src/main/java/com/github/nmorel/gwtjackson/client/AbstractConfiguration.java)) are supported. For any additional ones, you have to whitelist them.

The last release notes are available here : https://github.com/nmorel/gwt-jackson/releases

