### PR TITLE
Make slots typesafe

### DIFF
--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/HasSlots.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/HasSlots.java
@@ -16,6 +16,16 @@
 
 package com.gwtplatform.mvp.client;
 
+import java.util.List;
+import java.util.Set;
+
+import com.gwtplatform.mvp.client.presenter.slots.ISingleSlot;
+import com.gwtplatform.mvp.client.presenter.slots.ISlot;
+import com.gwtplatform.mvp.client.presenter.slots.MultiSlot;
+import com.gwtplatform.mvp.client.presenter.slots.OrderedSlot;
+import com.gwtplatform.mvp.client.presenter.slots.RemovableSlot;
+import com.gwtplatform.mvp.client.presenter.slots.Slot;
+
 /**
  * Interface of objects containing slots in which {@link PresenterWidget} can
  * be inserted.
@@ -38,6 +48,94 @@ package com.gwtplatform.mvp.client;
  */
 public interface HasSlots {
     /**
+    * This method adds some content in a specific slot of the {@link Presenter}.
+    * The attached {@link View} should manage this slot when its
+    * {@link View#addToSlot(Object, com.google.gwt.user.client.ui.Widget)} is called.
+    * <p/>
+    * Contrary to the {@link #setInSlot} method, no
+    * {@link com.gwtplatform.mvp.client.proxy.ResetPresentersEvent} is fired,
+    * so {@link PresenterWidget#onReset()} is not invoked.
+    * <p/>
+    * For more details on slots, see {@link HasSlots}.
+    *
+    * @param slot An opaque object identifying which slot this content is being
+    * added into.
+    * @param content The content, a {@link PresenterWidget}. Passing {@code null}
+    * will not add anything.
+    */
+    @Deprecated
+    void addToSlot(Object slot, PresenterWidget<?> content);
+
+    /**
+    * This method clears the content in a specific slot. No
+    * {@link com.gwtplatform.mvp.client.proxy.ResetPresentersEvent} is fired.
+    * The attached {@link View} should manage this slot when its
+    * {@link View#setInSlot(Object, com.google.gwt.user.client.ui.Widget)} is called. It should also clear
+    * the slot when the {@link View#setInSlot(Object, com.google.gwt.user.client.ui.Widget)} method is
+    * called with {@code null} as a parameter.
+    * <p/>
+    * For more details on slots, see {@link HasSlots}.
+    *
+    * @param slot An opaque object identifying which slot to clear.
+    */
+    @Deprecated
+    void clearSlot(Object slot);
+
+    /**
+    * This method removes some content in a specific slot of the
+    * {@link Presenter}. No
+    * {@link com.gwtplatform.mvp.client.proxy.ResetPresentersEvent} is fired.
+    * The attached {@link View} should manage this slot when its
+    * {@link View#removeFromSlot(Object, com.google.gwt.user.client.ui.Widget)} is called.
+    * <p/>
+    * For more details on slots, see {@link HasSlots}.
+    *
+    * @param slot An opaque object identifying which slot this content is being
+    * removed from.
+    * @param content The content, a {@link PresenterWidget}. Passing {@code null}
+    * will not remove anything.
+    */
+    @Deprecated
+    void removeFromSlot(Object slot, PresenterWidget<?> content);
+
+    /**
+    * This method sets some content in a specific slot of the {@link Presenter}.
+    * A {@link com.gwtplatform.mvp.client.proxy.ResetPresentersEvent} will be fired
+    * after the top-most visible presenter is revealed, resulting in a call to
+    * {@link PresenterWidget#onReset()}.
+    * <p/>
+    * For more details on slots, see {@link HasSlots}.
+    *
+    * @param slot An opaque object identifying which slot this content is being
+    * set into. The attached view should know what to do with this slot.
+    * @param content The content, a {@link PresenterWidget}. Passing {@code null}
+    * will clear the slot.
+    */
+    @Deprecated
+    void setInSlot(Object slot, PresenterWidget<?> content);
+
+    /**
+    * This method sets some content in a specific slot of the {@link Presenter}.
+    * The attached {@link View} should manage this slot when its
+    * {@link View#setInSlot(Object, com.google.gwt.user.client.ui.Widget)} is called. It should also clear the
+    * slot when the {@code setInSlot} method is called with {@code null} as a
+    * parameter.
+    * <p/>
+    * For more details on slots, see {@link HasSlots}.
+    *
+    * @param slot An opaque object identifying which slot this content is being
+    * set into.
+    * @param content The content, a {@link PresenterWidget}. Passing {@code null}
+    * will clear the slot.
+    * @param performReset Pass {@code true} if you want a
+    * {@link com.gwtplatform.mvp.client.proxy.ResetPresentersEvent} to be fired
+    * after the content has been added and this presenter is visible, pass
+    * {@code false} otherwise.
+    */
+    @Deprecated
+    void setInSlot(Object slot, PresenterWidget<?> content, boolean performReset);
+
+    /**
      * This method adds some content in a specific slot of the {@link Presenter}.
      * The attached {@link View} should manage this slot when its
      * {@link View#addToSlot(Object, com.google.gwt.user.client.ui.Widget)} is called.
@@ -53,7 +151,7 @@ public interface HasSlots {
      * @param content The content, a {@link PresenterWidget}. Passing {@code null}
      *                will not add anything.
      */
-    void addToSlot(Object slot, PresenterWidget<?> content);
+    <T extends PresenterWidget<?>> void addToSlot(MultiSlot<T> slot, T child);
 
     /**
      * This method clears the content in a specific slot. No
@@ -67,7 +165,7 @@ public interface HasSlots {
      *
      * @param slot An opaque object identifying which slot to clear.
      */
-    void clearSlot(Object slot);
+    void clearSlot(RemovableSlot<?> slot);
 
     /**
      * This method removes some content in a specific slot of the
@@ -83,7 +181,7 @@ public interface HasSlots {
      * @param content The content, a {@link PresenterWidget}. Passing {@code null}
      *                will not remove anything.
      */
-    void removeFromSlot(Object slot, PresenterWidget<?> content);
+    <T extends PresenterWidget<?>> void removeFromSlot(RemovableSlot<T> slot, T child);
 
     /**
      * This method sets some content in a specific slot of the {@link Presenter}.
@@ -98,7 +196,7 @@ public interface HasSlots {
      * @param content The content, a {@link PresenterWidget}. Passing {@code null}
      *                will clear the slot.
      */
-    void setInSlot(Object slot, PresenterWidget<?> content);
+    <T extends PresenterWidget<?>> void setInSlot(ISlot<T> slot, T child);
 
     /**
      * This method sets some content in a specific slot of the {@link Presenter}.
@@ -118,5 +216,26 @@ public interface HasSlots {
      *                     after the content has been added and this presenter is visible, pass
      *                     {@code false} otherwise.
      */
-    void setInSlot(Object slot, PresenterWidget<?> content, boolean performReset);
+    <T extends PresenterWidget<?>> void setInSlot(ISlot<T> slot, T child, boolean performReset);
+
+    /**
+     * Get the child of SingleSlot.
+     * @param slot - the slot
+     * @return the child of the slot or null if the slot is empty.
+     */
+    <T extends PresenterWidget<?>> T getChild(ISingleSlot<T> slot);
+
+    /**
+     * Get the children of a slot.
+     * @param slot - the slot
+     * @return the children of the slot.
+     */
+    <T extends PresenterWidget<?>> Set<T> getChildren(Slot<T> slot);
+
+    /**
+     * Get the children of an ordered slot.
+     * @param slot - an ordered slot
+     * @return the children of the slot in a sorted list.
+     */
+    <T extends PresenterWidget<?> & Comparable<T>> List<T> getChildren(OrderedSlot<T> slot);
 }

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/HasSlots.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/HasSlots.java
@@ -19,8 +19,8 @@ package com.gwtplatform.mvp.client;
 import java.util.List;
 import java.util.Set;
 
-import com.gwtplatform.mvp.client.presenter.slots.ISingleSlot;
-import com.gwtplatform.mvp.client.presenter.slots.ISlot;
+import com.gwtplatform.mvp.client.presenter.slots.IsSingleSlot;
+import com.gwtplatform.mvp.client.presenter.slots.IsSlot;
 import com.gwtplatform.mvp.client.presenter.slots.MultiSlot;
 import com.gwtplatform.mvp.client.presenter.slots.OrderedSlot;
 import com.gwtplatform.mvp.client.presenter.slots.RemovableSlot;
@@ -62,6 +62,7 @@ public interface HasSlots {
     * added into.
     * @param content The content, a {@link PresenterWidget}. Passing {@code null}
     * will not add anything.
+    * @deprecated since 1.5. Use {@link #addToSlot(MultiSlot, PresenterWidget)} instead.
     */
     @Deprecated
     void addToSlot(Object slot, PresenterWidget<?> content);
@@ -77,6 +78,7 @@ public interface HasSlots {
     * For more details on slots, see {@link HasSlots}.
     *
     * @param slot An opaque object identifying which slot to clear.
+    * @deprecated since 1.5. Use {@link #clearSlot(RemovableSlot)} instead.
     */
     @Deprecated
     void clearSlot(Object slot);
@@ -94,6 +96,7 @@ public interface HasSlots {
     * removed from.
     * @param content The content, a {@link PresenterWidget}. Passing {@code null}
     * will not remove anything.
+    * @deprecated since 1.5. Use {@link #removeFromSlot(RemovableSlot, PresenterWidget)} instead.
     */
     @Deprecated
     void removeFromSlot(Object slot, PresenterWidget<?> content);
@@ -110,6 +113,7 @@ public interface HasSlots {
     * set into. The attached view should know what to do with this slot.
     * @param content The content, a {@link PresenterWidget}. Passing {@code null}
     * will clear the slot.
+    * @deprecated since 1.5. Use {@link #setInSlot(IsSlot, PresenterWidget)} instead.
     */
     @Deprecated
     void setInSlot(Object slot, PresenterWidget<?> content);
@@ -131,6 +135,7 @@ public interface HasSlots {
     * {@link com.gwtplatform.mvp.client.proxy.ResetPresentersEvent} to be fired
     * after the content has been added and this presenter is visible, pass
     * {@code false} otherwise.
+    * @deprecated since 1.5. Use {@link #setInSlot(IsSlot, PresenterWidget, boolean)} instead.
     */
     @Deprecated
     void setInSlot(Object slot, PresenterWidget<?> content, boolean performReset);
@@ -196,7 +201,7 @@ public interface HasSlots {
      * @param content The content, a {@link PresenterWidget}. Passing {@code null}
      *                will clear the slot.
      */
-    <T extends PresenterWidget<?>> void setInSlot(ISlot<T> slot, T child);
+    <T extends PresenterWidget<?>> void setInSlot(IsSlot<T> slot, T child);
 
     /**
      * This method sets some content in a specific slot of the {@link Presenter}.
@@ -216,14 +221,14 @@ public interface HasSlots {
      *                     after the content has been added and this presenter is visible, pass
      *                     {@code false} otherwise.
      */
-    <T extends PresenterWidget<?>> void setInSlot(ISlot<T> slot, T child, boolean performReset);
+    <T extends PresenterWidget<?>> void setInSlot(IsSlot<T> slot, T child, boolean performReset);
 
     /**
      * Get the child of SingleSlot.
      * @param slot - the slot
      * @return the child of the slot or null if the slot is empty.
      */
-    <T extends PresenterWidget<?>> T getChild(ISingleSlot<T> slot);
+    <T extends PresenterWidget<?>> T getChild(IsSingleSlot<T> slot);
 
     /**
      * Get the children of a slot.

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/RootPresenter.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/RootPresenter.java
@@ -28,6 +28,7 @@ import com.google.gwt.user.client.ui.RootLayoutPanel;
 import com.google.gwt.user.client.ui.RootPanel;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.web.bindery.event.shared.EventBus;
+import com.gwtplatform.mvp.client.presenter.slots.SingleSlot;
 import com.gwtplatform.mvp.client.proxy.LockInteractionEvent;
 import com.gwtplatform.mvp.client.proxy.LockInteractionHandler;
 import com.gwtplatform.mvp.client.proxy.ResetPresentersEvent;
@@ -145,7 +146,7 @@ public class RootPresenter extends PresenterWidget<RootPresenter.RootView>
         }
     }
 
-    private static final Object rootSlot = new Object();
+    private static final SingleSlot<Presenter<?,?>> rootSlot = new SingleSlot<Presenter<?,?>>();
 
     private boolean isResetting;
 

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/ViewImpl.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/ViewImpl.java
@@ -29,7 +29,7 @@ import com.google.gwt.user.client.ui.HasWidgets;
 import com.google.gwt.user.client.ui.InsertPanel;
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.Widget;
-import com.gwtplatform.mvp.client.presenter.slots.ISingleSlot;
+import com.gwtplatform.mvp.client.presenter.slots.IsSingleSlot;
 import com.gwtplatform.mvp.client.presenter.slots.OrderedSlot;
 import com.gwtplatform.mvp.client.presenter.slots.Slot;
 
@@ -46,7 +46,7 @@ public abstract class ViewImpl implements View {
     private Widget widget;
     private Map<Object, HasOneWidget> oneWidgetSlots = new HashMap<Object, HasOneWidget>();
 
-    private Map<Object,HasWidgets> hasWidgetSlots = new HashMap<Object, HasWidgets>();
+    private Map<Object, HasWidgets> hasWidgetSlots = new HashMap<Object, HasWidgets>();
 
     private Map<OrderedSlot<?>, List<Comparable<Comparable<?>>>> orderedSlots
             = new HashMap<OrderedSlot<?>, List<Comparable<Comparable<?>>>>();
@@ -55,17 +55,15 @@ public abstract class ViewImpl implements View {
     @Override
     public void addToSlot(Object slot, IsWidget content) {
         if (hasWidgetSlots.containsKey(slot)) {
-            if (orderedSlots.containsKey(slot)) {
-                List<Comparable<Comparable<?>>> list = orderedSlots.get(slot);
-                list.add((Comparable<Comparable<?>>) content);
-                Collections.sort(list);
-                int index = Collections.binarySearch(list, (Comparable<Comparable<?>>) content);
+            hasWidgetSlots.get(slot).add(content.asWidget());
+        } else if (orderedSlots.containsKey(slot)) {
+            List<Comparable<Comparable<?>>> list = orderedSlots.get(slot);
+            list.add((Comparable<Comparable<?>>) content);
+            Collections.sort(list);
+            int index = Collections.binarySearch(list, (Comparable<Comparable<?>>) content);
 
-                InsertPanel insertPanel = (InsertPanel) hasWidgetSlots.get(slot);
-                insertPanel.insert(content.asWidget(), index);
-            } else {
-                hasWidgetSlots.get(slot).add(content.asWidget());
-            }
+            InsertPanel insertPanel = (InsertPanel) hasWidgetSlots.get(slot);
+            insertPanel.insert(content.asWidget(), index);
         }
     }
 
@@ -77,9 +75,8 @@ public abstract class ViewImpl implements View {
             }
         } else if (hasWidgetSlots.containsKey(slot)) {
             hasWidgetSlots.get(slot).remove(content.asWidget());
-            if (orderedSlots.containsKey(slot)) {
-                orderedSlots.get(slot).remove(content);
-            }
+        } else if (orderedSlots.containsKey(slot)) {
+            orderedSlots.get(slot).remove(content);
         }
     }
 
@@ -93,11 +90,10 @@ public abstract class ViewImpl implements View {
             if (content != null) {
                 hasWidgetSlots.get(slot).add(content.asWidget());
             }
-            if (orderedSlots.containsKey(slot)) {
-                orderedSlots.get(slot).clear();
-                if (content != null) {
-                    orderedSlots.get(slot).add((Comparable<Comparable<?>>) content);
-                }
+        } else if (orderedSlots.containsKey(slot)) {
+            orderedSlots.get(slot).clear();
+            if (content != null) {
+                orderedSlots.get(slot).add((Comparable<Comparable<?>>) content);
             }
         }
     }
@@ -114,16 +110,16 @@ public abstract class ViewImpl implements View {
     /**
      * Link a slot to a container.
      * @param slot - the slot
-     * @param container - the container must implement HasWidgets.ForIsWidget.
+     * @param container - the container must implement HasWidgets.
      */
-    protected void bindSlot(ISingleSlot<?> slot, HasWidgets container) {
+    protected void bindSlot(IsSingleSlot<?> slot, HasWidgets container) {
         internalBindSlot(slot, container);
     }
 
     /**
      * Link a slot to a container.
      * @param slot - the slot
-     * @param container - the container must implement HasWidgets.ForIsWidget.
+     * @param container - the container must implement HasWidgets.
      */
     protected void bindSlot(Slot<?> slot, HasWidgets container) {
         internalBindSlot(slot, container);
@@ -132,12 +128,11 @@ public abstract class ViewImpl implements View {
     /**
      * Link a slot to a container.
      * @param slot - the slot
-     * @param container - the container must implement HasWidgets.ForIsWidget.
+     * @param container - the container must implement HasWidgets & InsertPanel.
      */
     protected <T extends HasWidgets & InsertPanel> void bindSlot(
             OrderedSlot<?> slot, T container) {
         orderedSlots.put(slot, new ArrayList<Comparable<Comparable<?>>>());
-        hasWidgetSlots.put(slot, container);
     }
 
     protected void initWidget(IsWidget widget) {

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/ViewImpl.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/ViewImpl.java
@@ -16,10 +16,22 @@
 
 package com.gwtplatform.mvp.client;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import com.google.gwt.event.logical.shared.AttachEvent;
 import com.google.gwt.event.logical.shared.AttachEvent.Handler;
+import com.google.gwt.user.client.ui.HasOneWidget;
+import com.google.gwt.user.client.ui.HasWidgets;
+import com.google.gwt.user.client.ui.InsertPanel;
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.Widget;
+import com.gwtplatform.mvp.client.presenter.slots.ISingleSlot;
+import com.gwtplatform.mvp.client.presenter.slots.OrderedSlot;
+import com.gwtplatform.mvp.client.presenter.slots.Slot;
 
 /**
  * A simple implementation of {@link View} that simply disregard every call to {@link #setInSlot(Object, IsWidget)},
@@ -32,17 +44,62 @@ import com.google.gwt.user.client.ui.Widget;
  */
 public abstract class ViewImpl implements View {
     private Widget widget;
+    private Map<Object, HasOneWidget> oneWidgetSlots = new HashMap<Object, HasOneWidget>();
 
+    private Map<Object,HasWidgets> hasWidgetSlots = new HashMap<Object, HasWidgets>();
+
+    private Map<OrderedSlot<?>, List<Comparable<Comparable<?>>>> orderedSlots
+            = new HashMap<OrderedSlot<?>, List<Comparable<Comparable<?>>>>();
+
+    @SuppressWarnings("unchecked")
     @Override
     public void addToSlot(Object slot, IsWidget content) {
+        if (hasWidgetSlots.containsKey(slot)) {
+            if (orderedSlots.containsKey(slot)) {
+                List<Comparable<Comparable<?>>> list = orderedSlots.get(slot);
+                list.add((Comparable<Comparable<?>>) content);
+                Collections.sort(list);
+                int index = Collections.binarySearch(list, (Comparable<Comparable<?>>) content);
+
+                InsertPanel insertPanel = (InsertPanel) hasWidgetSlots.get(slot);
+                insertPanel.insert(content.asWidget(), index);
+            } else {
+                hasWidgetSlots.get(slot).add(content.asWidget());
+            }
+        }
     }
 
     @Override
     public void removeFromSlot(Object slot, IsWidget content) {
+        if (oneWidgetSlots.containsKey(slot)) {
+            if (oneWidgetSlots.get(slot).getWidget() == content.asWidget()) {
+                oneWidgetSlots.get(slot).setWidget(null);
+            }
+        } else if (hasWidgetSlots.containsKey(slot)) {
+            hasWidgetSlots.get(slot).remove(content.asWidget());
+            if (orderedSlots.containsKey(slot)) {
+                orderedSlots.get(slot).remove(content);
+            }
+        }
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public void setInSlot(Object slot, IsWidget content) {
+        if (oneWidgetSlots.containsKey(slot)) {
+            oneWidgetSlots.get(slot).setWidget(content);
+        } else if (hasWidgetSlots.containsKey(slot)) {
+            hasWidgetSlots.get(slot).clear();
+            if (content != null) {
+                hasWidgetSlots.get(slot).add(content.asWidget());
+            }
+            if (orderedSlots.containsKey(slot)) {
+                orderedSlots.get(slot).clear();
+                if (content != null) {
+                    orderedSlots.get(slot).add((Comparable<Comparable<?>>) content);
+                }
+            }
+        }
     }
 
     @Override
@@ -52,6 +109,35 @@ public abstract class ViewImpl implements View {
         }
 
         return widget;
+    }
+
+    /**
+     * Link a slot to a container.
+     * @param slot - the slot
+     * @param container - the container must implement HasWidgets.ForIsWidget.
+     */
+    protected void bindSlot(ISingleSlot<?> slot, HasWidgets container) {
+        internalBindSlot(slot, container);
+    }
+
+    /**
+     * Link a slot to a container.
+     * @param slot - the slot
+     * @param container - the container must implement HasWidgets.ForIsWidget.
+     */
+    protected void bindSlot(Slot<?> slot, HasWidgets container) {
+        internalBindSlot(slot, container);
+    }
+
+    /**
+     * Link a slot to a container.
+     * @param slot - the slot
+     * @param container - the container must implement HasWidgets.ForIsWidget.
+     */
+    protected <T extends HasWidgets & InsertPanel> void bindSlot(
+            OrderedSlot<?> slot, T container) {
+        orderedSlots.put(slot, new ArrayList<Comparable<Comparable<?>>>());
+        hasWidgetSlots.put(slot, container);
     }
 
     protected void initWidget(IsWidget widget) {
@@ -92,5 +178,13 @@ public abstract class ViewImpl implements View {
      * call to {@link #onAttach()}
      */
     protected void onDetach() {
+    }
+
+    private void internalBindSlot(Object slot, HasWidgets container) {
+        if (container instanceof HasOneWidget) {
+            oneWidgetSlots.put(slot, (HasOneWidget) container);
+        } else {
+            hasWidgetSlots.put(slot, container);
+        }
     }
 }

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/ViewImpl.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/ViewImpl.java
@@ -55,15 +55,17 @@ public abstract class ViewImpl implements View {
     @Override
     public void addToSlot(Object slot, IsWidget content) {
         if (hasWidgetSlots.containsKey(slot)) {
-            hasWidgetSlots.get(slot).add(content.asWidget());
-        } else if (orderedSlots.containsKey(slot)) {
-            List<Comparable<Comparable<?>>> list = orderedSlots.get(slot);
-            list.add((Comparable<Comparable<?>>) content);
-            Collections.sort(list);
-            int index = Collections.binarySearch(list, (Comparable<Comparable<?>>) content);
+            if (orderedSlots.containsKey(slot)) {
+                List<Comparable<Comparable<?>>> list = orderedSlots.get(slot);
+                list.add((Comparable<Comparable<?>>) content);
+                Collections.sort(list);
+                int index = Collections.binarySearch(list, (Comparable<Comparable<?>>) content);
 
-            InsertPanel insertPanel = (InsertPanel) hasWidgetSlots.get(slot);
-            insertPanel.insert(content.asWidget(), index);
+                InsertPanel insertPanel = (InsertPanel) hasWidgetSlots.get(slot);
+                insertPanel.insert(content.asWidget(), index);
+            } else {
+                hasWidgetSlots.get(slot).add(content.asWidget());
+            }
         }
     }
 
@@ -75,8 +77,9 @@ public abstract class ViewImpl implements View {
             }
         } else if (hasWidgetSlots.containsKey(slot)) {
             hasWidgetSlots.get(slot).remove(content.asWidget());
-        } else if (orderedSlots.containsKey(slot)) {
-            orderedSlots.get(slot).remove(content);
+            if (orderedSlots.containsKey(slot)) {
+                orderedSlots.get(slot).remove(content);
+            }
         }
     }
 
@@ -90,10 +93,11 @@ public abstract class ViewImpl implements View {
             if (content != null) {
                 hasWidgetSlots.get(slot).add(content.asWidget());
             }
-        } else if (orderedSlots.containsKey(slot)) {
-            orderedSlots.get(slot).clear();
-            if (content != null) {
-                orderedSlots.get(slot).add((Comparable<Comparable<?>>) content);
+            if (orderedSlots.containsKey(slot)) {
+                orderedSlots.get(slot).clear();
+                if (content != null) {
+                    orderedSlots.get(slot).add((Comparable<Comparable<?>>) content);
+                }
             }
         }
     }
@@ -128,11 +132,12 @@ public abstract class ViewImpl implements View {
     /**
      * Link a slot to a container.
      * @param slot - the slot
-     * @param container - the container must implement HasWidgets & InsertPanel.
+     * @param container - the container must implement HasWidgets &amp; InsertPanel.
      */
     protected <T extends HasWidgets & InsertPanel> void bindSlot(
             OrderedSlot<?> slot, T container) {
         orderedSlots.put(slot, new ArrayList<Comparable<Comparable<?>>>());
+        hasWidgetSlots.put(slot, container);
     }
 
     protected void initWidget(IsWidget widget) {

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/annotations/ContentSlot.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/annotations/ContentSlot.java
@@ -24,6 +24,7 @@ import java.lang.annotation.Target;
 * this event, a child presenter is inserted in the presenter's view. You should
 * make sure the view handles event of this type in its
 * {@link com.gwtplatform.mvp.client.View#setInSlot(Object, com.google.gwt.user.client.ui.Widget)} method.
+* @deprecated since 1.5. use {@link om.gwtplatform.mvp.client.presenter.slots.NestedSlot} instead.
 */
 @Deprecated
 @Target(ElementType.FIELD)

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/annotations/ContentSlot.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/annotations/ContentSlot.java
@@ -15,18 +15,17 @@
  */
 
 package com.gwtplatform.mvp.client.annotations;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
-
 /**
- * Use this annotation in classes implementing {@link com.gwtplatform.mvp.client.Presenter} and that have
- * slots to display child presenters. This annotates every static field
- * containing a type of event that is monitored by this presenter. When handling
- * this event, a child presenter is inserted in the presenter's view. You should
- * make sure the view handles event of this type in its
- * {@link com.gwtplatform.mvp.client.View#setInSlot(Object, com.google.gwt.user.client.ui.Widget)} method.
- */
+* Use this annotation in classes implementing {@link com.gwtplatform.mvp.client.Presenter} and that have
+* slots to display child presenters. This annotates every static field
+* containing a type of event that is monitored by this presenter. When handling
+* this event, a child presenter is inserted in the presenter's view. You should
+* make sure the view handles event of this type in its
+* {@link com.gwtplatform.mvp.client.View#setInSlot(Object, com.google.gwt.user.client.ui.Widget)} method.
+*/
+@Deprecated
 @Target(ElementType.FIELD)
 public @interface ContentSlot {
 }

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/CrashingLegacySlotConvertor.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/CrashingLegacySlotConvertor.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2014 ArcBees Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.gwtplatform.mvp.client.presenter.slots;
+
+public class CrashingLegacySlotConvertor extends LegacySlotConvertor {
+    @Override
+    protected LegacySlot get(Object slot) {
+        assert false : LegacySlotConvertor.WARNING_MESSAGE;
+        return super.get(slot);
+    }
+}

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/ISingleSlot.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/ISingleSlot.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2014 ArcBees Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.gwtplatform.mvp.client.presenter.slots;
+
+import com.gwtplatform.mvp.client.PresenterWidget;
+
+/**
+ * The Interface ISingleSlot.
+ *
+ * @param <T> the generic type
+ */
+public interface ISingleSlot<T extends PresenterWidget<?>> extends ISlot<T> {
+
+}

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/ISlot.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/ISlot.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2014 ArcBees Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.gwtplatform.mvp.client.presenter.slots;
+
+import com.gwtplatform.mvp.client.PresenterWidget;
+
+public interface ISlot<T extends PresenterWidget<?>> {
+    boolean isPopup();
+
+    boolean isRemovable();
+
+    Object getRawSlot();
+}

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/IsSingleSlot.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/IsSingleSlot.java
@@ -17,10 +17,11 @@ package com.gwtplatform.mvp.client.presenter.slots;
 
 import com.gwtplatform.mvp.client.PresenterWidget;
 
-public interface ISlot<T extends PresenterWidget<?>> {
-    boolean isPopup();
+/**
+ * A slot that can only hold one presenter.
+ *
+ * @param <T> the presenter type
+ */
+public interface IsSingleSlot<T extends PresenterWidget<?>> extends IsSlot<T> {
 
-    boolean isRemovable();
-
-    Object getRawSlot();
 }

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/IsSlot.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/IsSlot.java
@@ -17,11 +17,10 @@ package com.gwtplatform.mvp.client.presenter.slots;
 
 import com.gwtplatform.mvp.client.PresenterWidget;
 
-/**
- * The Interface ISingleSlot.
- *
- * @param <T> the generic type
- */
-public interface ISingleSlot<T extends PresenterWidget<?>> extends ISlot<T> {
+public interface IsSlot<T extends PresenterWidget<?>> {
+    boolean isPopup();
 
+    boolean isRemovable();
+
+    Object getRawSlot();
 }

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/LegacySlot.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/LegacySlot.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2014 ArcBees Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.gwtplatform.mvp.client.presenter.slots;
+
+import com.gwtplatform.mvp.client.PresenterWidget;
+
+public class LegacySlot extends Slot<PresenterWidget<?>> {
+    private final Object rawSlot;
+
+    LegacySlot(Object rawSlot) {
+        this.rawSlot = rawSlot;
+    }
+
+    @Override
+    public Object getRawSlot() {
+        return rawSlot;
+    }
+}

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/LegacySlotConvertor.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/LegacySlotConvertor.java
@@ -13,19 +13,37 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package com.gwtplatform.mvp.client.presenter.slots;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.logging.Logger;
+
+import com.google.gwt.core.shared.GWT;
 
 public class LegacySlotConvertor {
-    private static Map<Object, LegacySlot> legacySlotMap =
+    static String WARNING_MESSAGE = "Warning: You're using an untyped slot!\n"
+            + "Untyped slots are dangerous! Please upgrade your slots using\n"
+            + "the Arcbee's easy upgrade tool at\n"
+            + "https://arcbees.github.io/gwtp-slot-upgrader";
+
+    private static final Logger LOGGER = Logger.getLogger(LegacySlotConvertor.class.getName());
+
+    private static LegacySlotConvertor INSTANCE = GWT.create(LegacySlotConvertor.class);
+
+    private Map<Object, LegacySlot> legacySlotMap =
             new HashMap<Object, LegacySlot>();
 
-    public static LegacySlot convert(Object slot) {
+    protected LegacySlot get(Object slot) {
         if (!legacySlotMap.containsKey(slot)) {
+            LOGGER.severe(WARNING_MESSAGE);
             legacySlotMap.put(slot, new LegacySlot(slot));
         }
         return legacySlotMap.get(slot);
+    }
+
+    public static LegacySlot convert(Object slot) {
+        return INSTANCE.get(slot);
     }
 }

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/LegacySlotConvertor.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/LegacySlotConvertor.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2014 ArcBees Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.gwtplatform.mvp.client.presenter.slots;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class LegacySlotConvertor {
+    private static Map<Object, LegacySlot> legacySlotMap =
+            new HashMap<Object, LegacySlot>();
+
+    public static LegacySlot convert(Object slot) {
+        if (!legacySlotMap.containsKey(slot)) {
+            legacySlotMap.put(slot, new LegacySlot(slot));
+        }
+        return legacySlotMap.get(slot);
+    }
+}

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/MultiSlot.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/MultiSlot.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2014 ArcBees Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.gwtplatform.mvp.client.presenter.slots;
+
+import com.gwtplatform.mvp.client.PresenterWidget;
+
+public abstract class MultiSlot<T extends PresenterWidget<?>> implements RemovableSlot<T> {
+    @Override
+    public boolean isRemovable() {
+        return true;
+    }
+    @Override
+    public boolean isPopup() {
+        return false;
+    }
+    @Override
+    public Object getRawSlot() {
+        return this;
+    }
+}

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/MultiSlot.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/MultiSlot.java
@@ -22,10 +22,12 @@ public abstract class MultiSlot<T extends PresenterWidget<?>> implements Removab
     public boolean isRemovable() {
         return true;
     }
+
     @Override
     public boolean isPopup() {
         return false;
     }
+
     @Override
     public Object getRawSlot() {
         return this;

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/NestedSlot.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/NestedSlot.java
@@ -20,22 +20,23 @@ import com.gwtplatform.mvp.client.Presenter;
 import com.gwtplatform.mvp.client.proxy.RevealContentHandler;
 
 /**
- * Use ContentSlot in classes extending {@link com.gwtplatform.mvp.client.Presenter}
+ * Use NestedSlot in classes extending {@link com.gwtplatform.mvp.client.Presenter}
  * to automatically display child presenters.
  *
- * @param <T> - the type of presenter that this slot can take.
  * @see: https://github.com/ArcBees/GWTP/wiki/Presenter-%22Slots%22
  */
 public class NestedSlot extends GwtEvent.Type<RevealContentHandler<?>>
-        implements ISingleSlot<Presenter<?,?>> {
+        implements IsSingleSlot<Presenter<?,?>> {
     @Override
     public boolean isPopup() {
         return false;
     }
+
     @Override
     public boolean isRemovable() {
         return true;
     }
+
     @Override
     public Object getRawSlot() {
         return this;

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/NestedSlot.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/NestedSlot.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2014 ArcBees Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.gwtplatform.mvp.client.presenter.slots;
+
+import com.google.gwt.event.shared.GwtEvent;
+import com.gwtplatform.mvp.client.Presenter;
+import com.gwtplatform.mvp.client.proxy.RevealContentHandler;
+
+/**
+ * Use ContentSlot in classes extending {@link com.gwtplatform.mvp.client.Presenter}
+ * to automatically display child presenters.
+ *
+ * @param <T> - the type of presenter that this slot can take.
+ * @see: https://github.com/ArcBees/GWTP/wiki/Presenter-%22Slots%22
+ */
+public class NestedSlot extends GwtEvent.Type<RevealContentHandler<?>>
+        implements ISingleSlot<Presenter<?,?>> {
+    @Override
+    public boolean isPopup() {
+        return false;
+    }
+    @Override
+    public boolean isRemovable() {
+        return true;
+    }
+    @Override
+    public Object getRawSlot() {
+        return this;
+    }
+}

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/OrderedSlot.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/OrderedSlot.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2014 ArcBees Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.gwtplatform.mvp.client.presenter.slots;
+
+import com.gwtplatform.mvp.client.PresenterWidget;
+
+/**
+ * A slot for an ordered presenter.
+ * The presenter placed in this slot must implement comparable and will
+ * be automatically placed in order in the view.
+ * @param <T> - The type of presenter, must extend comparable.
+ */
+public class OrderedSlot<T extends PresenterWidget<?> & Comparable<T>> extends MultiSlot<T> {
+}

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/PermanentSlot.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/PermanentSlot.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2014 ArcBees Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.gwtplatform.mvp.client.presenter.slots;
+
+import com.gwtplatform.mvp.client.PresenterWidget;
+
+/**
+ * A slot that can only take one presenter.
+ * Once a presenter is in this slot it can never be removed.
+ *
+ * @param <T> - the type of presenter that this slot can take.
+ */
+public class PermanentSlot<T extends PresenterWidget<?>> implements ISingleSlot<T> {
+    @Override
+    public boolean isPopup() {
+        return false;
+    }
+    @Override
+    public boolean isRemovable() {
+        return false;
+    }
+    @Override
+    public Object getRawSlot() {
+        return this;
+    }
+}

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/PermanentSlot.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/PermanentSlot.java
@@ -23,7 +23,7 @@ import com.gwtplatform.mvp.client.PresenterWidget;
  *
  * @param <T> - the type of presenter that this slot can take.
  */
-public class PermanentSlot<T extends PresenterWidget<?>> implements ISingleSlot<T> {
+public class PermanentSlot<T extends PresenterWidget<?>> implements IsSingleSlot<T> {
     @Override
     public boolean isPopup() {
         return false;

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/PopupSlot.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/PopupSlot.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2014 ArcBees Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.gwtplatform.mvp.client.presenter.slots;
+
+import com.gwtplatform.mvp.client.PopupView;
+import com.gwtplatform.mvp.client.PresenterWidget;
+
+/**
+ * A slot that can take multiple PopupPresenters
+ * Acts like {@link Slot} except will hide and show the PopupPresenter when
+ * appropriate.
+ *
+ * @param <T> - the type of presenter that this slot can take.
+ */
+public class PopupSlot<T extends PresenterWidget<? extends PopupView>> extends MultiSlot<T> {
+    @Override
+    public boolean isPopup() {
+        return true;
+    }
+}

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/RemovableSlot.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/RemovableSlot.java
@@ -22,6 +22,6 @@ import com.gwtplatform.mvp.client.PresenterWidget;
  * Slots must implement RemovableSlot to allow presenters to be
  * removed once they are added to the slot.
  */
-public interface RemovableSlot<T extends PresenterWidget<?>> extends ISlot<T> {
+public interface RemovableSlot<T extends PresenterWidget<?>> extends IsSlot<T> {
 
 }

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/RemovableSlot.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/RemovableSlot.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2014 ArcBees Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.gwtplatform.mvp.client.presenter.slots;
+
+import com.gwtplatform.mvp.client.PresenterWidget;
+
+/**
+ * Only PermanentSlot does not implement this interface.
+ * Slots must implement RemovableSlot to allow presenters to be
+ * removed once they are added to the slot.
+ */
+public interface RemovableSlot<T extends PresenterWidget<?>> extends ISlot<T> {
+
+}

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/SingleSlot.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/SingleSlot.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2014 ArcBees Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.gwtplatform.mvp.client.presenter.slots;
+
+import com.gwtplatform.mvp.client.PresenterWidget;
+
+/**
+ * A slot that can only take one presenter at a time.
+ *
+ * @param <T> - the type of presenter that this slot can take.
+ */
+public class SingleSlot<T extends PresenterWidget<?>> implements ISingleSlot<T>, RemovableSlot<T> {
+    @Override
+    public boolean isPopup() {
+        return false;
+    }
+    @Override
+    public boolean isRemovable() {
+        return true;
+    }
+    @Override
+    public Object getRawSlot() {
+        return this;
+    }
+}

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/SingleSlot.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/SingleSlot.java
@@ -22,7 +22,7 @@ import com.gwtplatform.mvp.client.PresenterWidget;
  *
  * @param <T> - the type of presenter that this slot can take.
  */
-public class SingleSlot<T extends PresenterWidget<?>> implements ISingleSlot<T>, RemovableSlot<T> {
+public class SingleSlot<T extends PresenterWidget<?>> implements IsSingleSlot<T>, RemovableSlot<T> {
     @Override
     public boolean isPopup() {
         return false;

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/Slot.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/Slot.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2014 ArcBees Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.gwtplatform.mvp.client.presenter.slots;
+
+import com.gwtplatform.mvp.client.PresenterWidget;
+
+/**
+ * A slot that can take one or many presenters.
+ *
+ * @param <T> - The type of presenter this slot can take.
+ */
+public class Slot<T extends PresenterWidget<?>> extends MultiSlot<T> {
+}

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/RevealContentHandler.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/RevealContentHandler.java
@@ -21,6 +21,7 @@ import com.google.gwt.event.shared.EventHandler;
 import com.google.gwt.user.client.Command;
 import com.google.web.bindery.event.shared.EventBus;
 import com.gwtplatform.mvp.client.Presenter;
+import com.gwtplatform.mvp.client.presenter.slots.NestedSlot;
 
 /**
  * This is the handler class for {@link RevealContentEvent}. It should be used
@@ -62,8 +63,13 @@ public class RevealContentHandler<T extends Presenter<?, ?>> implements EventHan
                     @Override
                     public void execute() {
                         presenter.forceReveal();
-                        presenter.setInSlot(revealContentEvent.getAssociatedType(),
-                                revealContentEvent.getContent());
+                        if (revealContentEvent.getAssociatedType() instanceof NestedSlot) {
+                            presenter.setInSlot((NestedSlot) revealContentEvent.getAssociatedType(),
+                                    revealContentEvent.getContent());
+                        } else {
+                            presenter.setInSlot(revealContentEvent.getAssociatedType(),
+                                    revealContentEvent.getContent());
+                        }
                     }
                 });
             }

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/ClassCollection.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/ClassCollection.java
@@ -31,6 +31,7 @@ import com.gwtplatform.mvp.client.DelayedBind;
 import com.gwtplatform.mvp.client.Presenter;
 import com.gwtplatform.mvp.client.RequestTabsHandler;
 import com.gwtplatform.mvp.client.TabData;
+import com.gwtplatform.mvp.client.presenter.slots.NestedSlot;
 import com.gwtplatform.mvp.client.proxy.Gatekeeper;
 import com.gwtplatform.mvp.client.proxy.NonLeafTabContentProxy;
 import com.gwtplatform.mvp.client.proxy.NonLeafTabContentProxyImpl;
@@ -81,6 +82,7 @@ public class ClassCollection {
     static final String tabContentProxyPlaceImplClassName =
             TabContentProxyPlaceImpl.class.getCanonicalName();
     static final String typeClassName = Type.class.getCanonicalName();
+    static final String nestedSlotClassName = NestedSlot.class.getCanonicalName();
     static final String tabDataClassName = TabData.class.getCanonicalName();
     final JGenericType asyncProviderClass;
     final JClassType baseGinjectorClass;
@@ -101,6 +103,7 @@ public class ClassCollection {
     final JClassType tabContentProxyClass;
     final JClassType nonLeafTabContentProxyClass;
     final JClassType typeClass;
+    final JClassType nestedSlotClass;
 
     public ClassCollection(TypeOracle oracle) {
         // Find the required base types
@@ -123,5 +126,6 @@ public class ClassCollection {
         eventHandlerClass = oracle.findType(eventHandlerClassName);
         setPlaceTitleHandlerClass = oracle.findType(setPlaceTitleHandlerClassName);
         tabDataClass = oracle.findType(tabDataClassName);
+        nestedSlotClass = oracle.findType(nestedSlotClassName);
     }
 }

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/ClassInspector.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/ClassInspector.java
@@ -261,9 +261,10 @@ public class ClassInspector {
                 if (field.getAnnotation(annotation) != null) {
                     JParameterizedType parameterizedType = field.getType().isParameterized();
                     if (!field.isStatic()
-                            || parameterizedType == null
-                            || !type.isAssignableFrom(parameterizedType)
-                            || !typeParameter.isAssignableFrom(parameterizedType.getTypeArgs()[0])) {
+                             || (typeParameter != null
+                             && (parameterizedType == null
+                             || !type.isAssignableFrom(parameterizedType)
+                             || !typeParameter.isAssignableFrom(parameterizedType.getTypeArgs()[0])))) {
                         logger.log(
                                 TreeLogger.ERROR, "Found the annotation @" + annotation.getSimpleName()
                                 + " on the invalid field '" + classType.getName() + "." + field.getName()
@@ -271,6 +272,19 @@ public class ClassInspector {
                                 + "<" + typeParameter.getName() + ">.", null);
                         throw new UnableToCompleteException();
                     }
+                    collection.add(field);
+                }
+            }
+        }
+    }
+
+    public void collectStaticFields(JClassType type,
+            List<JField> collection) throws UnableToCompleteException {
+        for (JClassType classType : inspectedClass.getFlattenedSupertypeHierarchy()) {
+            for (JField field : classType.getFields()) {
+                if (field.isStatic()
+                        && field.getType().getParameterizedQualifiedSourceName()
+                            .equals(type.getParameterizedQualifiedSourceName())) {
                     collection.add(field);
                 }
             }

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/ClassInspector.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/ClassInspector.java
@@ -261,10 +261,9 @@ public class ClassInspector {
                 if (field.getAnnotation(annotation) != null) {
                     JParameterizedType parameterizedType = field.getType().isParameterized();
                     if (!field.isStatic()
-                             || (typeParameter != null
-                             && (parameterizedType == null
+                             || parameterizedType == null
                              || !type.isAssignableFrom(parameterizedType)
-                             || !typeParameter.isAssignableFrom(parameterizedType.getTypeArgs()[0])))) {
+                             || !typeParameter.isAssignableFrom(parameterizedType.getTypeArgs()[0])) {
                         logger.log(
                                 TreeLogger.ERROR, "Found the annotation @" + annotation.getSimpleName()
                                 + " on the invalid field '" + classType.getName() + "." + field.getName()

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/ClassInspector.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/ClassInspector.java
@@ -261,9 +261,9 @@ public class ClassInspector {
                 if (field.getAnnotation(annotation) != null) {
                     JParameterizedType parameterizedType = field.getType().isParameterized();
                     if (!field.isStatic()
-                             || parameterizedType == null
-                             || !type.isAssignableFrom(parameterizedType)
-                             || !typeParameter.isAssignableFrom(parameterizedType.getTypeArgs()[0])) {
+                            || parameterizedType == null
+                            || !type.isAssignableFrom(parameterizedType)
+                            || !typeParameter.isAssignableFrom(parameterizedType.getTypeArgs()[0])) {
                         logger.log(
                                 TreeLogger.ERROR, "Found the annotation @" + annotation.getSimpleName()
                                 + " on the invalid field '" + classType.getName() + "." + field.getName()

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/PresenterInspector.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/PresenterInspector.java
@@ -95,6 +95,8 @@ public class PresenterInspector {
 
         findGetPresenterMethodName();
 
+        classInspector.collectStaticFields(classCollection.nestedSlotClass, contentSlots);
+
         classInspector.collectStaticAnnotatedFields(classCollection.typeClass,
                 classCollection.revealContentHandlerClass, ContentSlot.class, contentSlots);
 

--- a/gwtp-core/gwtp-mvp-client/src/main/resources/com/gwtplatform/mvp/Mvp.gwt.xml
+++ b/gwtp-core/gwtp-mvp-client/src/main/resources/com/gwtplatform/mvp/Mvp.gwt.xml
@@ -60,4 +60,23 @@
     <replace-with class="com.google.gwt.place.shared.PlaceHistoryHandler.DefaultHistorian">
         <when-type-assignable class="com.google.gwt.place.shared.PlaceHistoryHandler.Historian" />
     </replace-with>
+    
+    <!-- 
+    When set to true gwtp projects will crash in dev mode when a legacy slot is used!
+    Use this to be confident that no deprecated slot methods are used.
+    It will not change the behavior of compiled code. 
+    -->
+    <define-property values="true, false" name="gwtp.crashOnLegacySlot"/>
+    <set-property name="gwtp.crashOnLegacySlot" value="false"/>
+    
+    <replace-with class="com.gwtplatform.mvp.client.presenter.slots.LegacySlotConvertor">
+    	<when-type-is class="com.gwtplatform.mvp.client.presenter.slots.LegacySlotConvertor"/>
+  	</replace-with>
+  	
+  	<replace-with class="com.gwtplatform.mvp.client.presenter.slots.CrashingLegacySlotConvertor">
+    	<when-type-is class="com.gwtplatform.mvp.client.presenter.slots.LegacySlotConvertor"/>
+    	<all>
+    		<when-property-is name="gwtp.crashOnLegacySlot" value="true"/>
+    	</all>
+  	</replace-with>
 </module>

--- a/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/PresenterWidgetTest.java
+++ b/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/PresenterWidgetTest.java
@@ -32,6 +32,7 @@ import com.google.gwt.junit.GWTMockUtilities;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.web.bindery.event.shared.EventBus;
 import com.google.web.bindery.event.shared.HandlerRegistration;
+import com.gwtplatform.mvp.client.presenter.slots.Slot;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -322,7 +323,7 @@ public class PresenterWidgetTest {
             PresenterWidgetC contentC) {
 
         // Given
-        Object slotBC = new Object();
+        Slot<PresenterWidget<?>> slotBC = new Slot<PresenterWidget<?>>();
         presenterWidgetA.internalReveal();
 
         // When
@@ -373,7 +374,7 @@ public class PresenterWidgetTest {
             PresenterWidgetA presenterWidgetA,
             PresenterWidgetB contentB) {
         // Given
-        Object slotB = new Object();
+        Slot<PresenterWidget<?>> slotB = new Slot<PresenterWidget<?>>();
         presenterWidgetA.internalReveal();
         presenterWidgetA.setInSlot(slotB, contentB);
 
@@ -397,8 +398,8 @@ public class PresenterWidgetTest {
             PresenterWidgetA presenterWidgetA,
             PresenterWidgetB contentB) {
         // Given
-        Object slotA = new Object();
-        Object slotB = new Object();
+        Slot<PresenterWidget<?>> slotA = new Slot<PresenterWidget<?>>();
+        Slot<PresenterWidget<?>> slotB = new Slot<PresenterWidget<?>>();
         presenterWidgetA.internalReveal();
 
         // When
@@ -418,7 +419,7 @@ public class PresenterWidgetTest {
             PresenterWidgetB contentB,
             PresenterWidgetC contentC) {
         // Given
-        Object slotBC = new Object();
+        Slot<PresenterWidget<?>> slotBC = new Slot<PresenterWidget<?>>();
         presenterWidgetA.internalReveal();
         presenterWidgetA.addToSlot(slotBC, contentB);
         presenterWidgetA.addToSlot(slotBC, contentC);
@@ -440,8 +441,8 @@ public class PresenterWidgetTest {
             PresenterWidgetC contentCinB) {
         // Given
         // slot is empty in presenterWidgets, and it is NOT visible
-        Object slotB = new Object();
-        Object slotC = new Object();
+        Slot<PresenterWidget<?>> slotB = new Slot<PresenterWidget<?>>();
+        Slot<PresenterWidget<?>> slotC = new Slot<PresenterWidget<?>>();
         assertFalse(presenterWidgetA.isVisible());
         assertFalse(contentB.isVisible());
 
@@ -480,8 +481,8 @@ public class PresenterWidgetTest {
             PresenterWidgetC contentCinB) {
         // Given
         // slot is empty in presenterWidgets, and it is NOT visible
-        Object slotB = new Object();
-        Object slotC = new Object();
+        Slot<PresenterWidget<?>> slotB = new Slot<PresenterWidget<?>>();
+        Slot<PresenterWidget<?>> slotC = new Slot<PresenterWidget<?>>();
         assertFalse(presenterWidgetA.isVisible());
         assertFalse(contentB.isVisible());
 
@@ -523,8 +524,8 @@ public class PresenterWidgetTest {
             PresenterWidgetC contentCinB) {
 
         // Given
-        Object slotB = new Object();
-        Object slotC = new Object();
+        Slot<PresenterWidget<?>> slotB = new Slot<PresenterWidget<?>>();
+        Slot<PresenterWidget<?>> slotC = new Slot<PresenterWidget<?>>();
         presenterWidgetA.internalReveal();
 
         // When
@@ -556,8 +557,8 @@ public class PresenterWidgetTest {
             PresenterWidgetC contentC) {
         // Given
         // slot is empty in presenterWidget, and it is NOT visible
-        Object slotB = new Object();
-        Object slotC = new Object();
+        Slot<PresenterWidget<?>> slotB = new Slot<PresenterWidget<?>>();
+        Slot<PresenterWidget<?>> slotC = new Slot<PresenterWidget<?>>();
         assertFalse(presenterWidgetA.isVisible());
 
         // When
@@ -594,8 +595,8 @@ public class PresenterWidgetTest {
             PresenterWidgetB contentB,
             PresenterWidgetC contentC) {
         // Given
-        Object slotB = new Object();
-        Object slotC = new Object();
+        Slot<PresenterWidget<?>> slotB = new Slot<PresenterWidget<?>>();
+        Slot<PresenterWidget<?>> slotC = new Slot<PresenterWidget<?>>();
         presenterWidgetA.internalReveal();
 
         // When
@@ -624,7 +625,7 @@ public class PresenterWidgetTest {
             PresenterWidgetA presenterWidgetA,
             PresenterWidgetB contentB) {
         // Given
-        Object slotB = new Object();
+        Slot<PresenterWidget<?>> slotB = new Slot<PresenterWidget<?>>();
         presenterWidgetA.internalReveal();
         presenterWidgetA.setInSlot(slotB, contentB);
 
@@ -686,8 +687,8 @@ public class PresenterWidgetTest {
             PresenterWidgetB presenterWidgetB,
             PresenterWidgetC contentC) {
         // Given
-        Object slotCinA = new Object();
-        Object slotCinB = new Object();
+        Slot<PresenterWidget<?>> slotCinA = new Slot<PresenterWidget<?>>();
+        Slot<PresenterWidget<?>> slotCinB = new Slot<PresenterWidget<?>>();
         presenterWidgetA.internalReveal();
         presenterWidgetB.internalReveal();
 
@@ -706,8 +707,8 @@ public class PresenterWidgetTest {
             PresenterWidgetB presenterWidgetB,
             PresenterWidgetC contentC) {
         // Given
-        Object slotCinA = new Object();
-        Object slotCinB = new Object();
+        Slot<PresenterWidget<?>> slotCinA = new Slot<PresenterWidget<?>>();
+        Slot<PresenterWidget<?>> slotCinB = new Slot<PresenterWidget<?>>();
         presenterWidgetA.internalReveal();
         presenterWidgetB.internalReveal();
 

--- a/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/mvp/MainPresenterTestUtil.java
+++ b/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/mvp/MainPresenterTestUtil.java
@@ -19,23 +19,20 @@ package com.gwtplatform.mvp.client.mvp;
 import javax.inject.Inject;
 import javax.inject.Named;
 
-import com.google.gwt.event.shared.GwtEvent.Type;
 import com.google.web.bindery.event.shared.EventBus;
 import com.gwtplatform.mvp.client.Presenter;
 import com.gwtplatform.mvp.client.PresenterWidget;
 import com.gwtplatform.mvp.client.View;
-import com.gwtplatform.mvp.client.annotations.ContentSlot;
 import com.gwtplatform.mvp.client.annotations.ProxyStandard;
+import com.gwtplatform.mvp.client.presenter.slots.SingleSlot;
 import com.gwtplatform.mvp.client.proxy.Proxy;
-import com.gwtplatform.mvp.client.proxy.RevealContentHandler;
 
 /**
  * This is the test presenter.
  */
 public class MainPresenterTestUtil extends Presenter<MainPresenterTestUtil.MyView, MainPresenterTestUtil.MyProxy> {
 
-    @ContentSlot
-    public static final Type<RevealContentHandler<?>> SLOT_SetMainContent = new Type<RevealContentHandler<?>>();
+    public static final SingleSlot<PresenterWidget<?>> SLOT_SetMainContent = new SingleSlot<PresenterWidget<?>>();
 
     /**
      * Presenter's view.


### PR DESCRIPTION
This is backwards compatible to use the new features:

`@ContentSlot Type<RevealContentHandler<?>> CONTENT_SLOT = new Type<RevealContentHandler<?>>();`
becomes
`NestedSlot CONTENT_SLOT = new NestedSlot();`


`Object SLOT = new Object();`
becomes
`Slot SLOT = new Slot();`