### PR TITLE
Dispatch-Rest: Added ability to configure core bindings

### DIFF
--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/CoreModule.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/CoreModule.java
@@ -20,20 +20,25 @@ import javax.inject.Singleton;
 
 import com.google.gwt.inject.client.AbstractGinModule;
 import com.gwtplatform.dispatch.rest.client.RestDispatch;
-import com.gwtplatform.dispatch.rest.client.core.parameters.DefaultHttpParameterFactory;
 import com.gwtplatform.dispatch.rest.client.core.parameters.HttpParameterFactory;
 
 public class CoreModule extends AbstractGinModule {
+    private final CoreModuleBuilder builder;
+
+    CoreModule(CoreModuleBuilder builder) {
+        this.builder = builder;
+    }
+
     @Override
     protected void configure() {
-        bind(BodyFactory.class).to(DefaultBodyFactory.class).in(Singleton.class);
-        bind(CookieManager.class).to(DefaultCookieManager.class).in(Singleton.class);
-        bind(HeaderFactory.class).to(DefaultHeaderFactory.class).in(Singleton.class);
-        bind(UriFactory.class).to(DefaultUriFactory.class).in(Singleton.class);
-        bind(DispatchCallFactory.class).to(DefaultDispatchCallFactory.class).in(Singleton.class);
-        bind(RequestBuilderFactory.class).to(DefaultRequestBuilderFactory.class).in(Singleton.class);
-        bind(ResponseDeserializer.class).to(DefaultResponseDeserializer.class).in(Singleton.class);
-        bind(HttpParameterFactory.class).to(DefaultHttpParameterFactory.class).in(Singleton.class);
-        bind(RestDispatch.class).to(RestDispatchAsync.class).in(Singleton.class);
+        bind(BodyFactory.class).to(builder.getBodyFactory()).in(Singleton.class);
+        bind(CookieManager.class).to(builder.getCookieManager()).in(Singleton.class);
+        bind(HeaderFactory.class).to(builder.getHeaderFactory()).in(Singleton.class);
+        bind(UriFactory.class).to(builder.getUriFactory()).in(Singleton.class);
+        bind(DispatchCallFactory.class).to(builder.getDispatchCallFactory()).in(Singleton.class);
+        bind(RequestBuilderFactory.class).to(builder.getRequestBuilderFactory()).in(Singleton.class);
+        bind(ResponseDeserializer.class).to(builder.getResponseDeserializer()).in(Singleton.class);
+        bind(HttpParameterFactory.class).to(builder.getHttpParameterFactory()).in(Singleton.class);
+        bind(RestDispatch.class).to(builder.getRestDispatch()).in(Singleton.class);
     }
 }

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/CoreModuleBuilder.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/CoreModuleBuilder.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright 2015 ArcBees Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.gwtplatform.dispatch.rest.client.core;
+
+import com.gwtplatform.dispatch.rest.client.RestDispatch;
+import com.gwtplatform.dispatch.rest.client.core.parameters.DefaultHttpParameterFactory;
+import com.gwtplatform.dispatch.rest.client.core.parameters.HttpParameterFactory;
+import com.gwtplatform.dispatch.rest.client.gin.BaseRestDispatchModuleBuilder;
+
+public class CoreModuleBuilder extends BaseRestDispatchModuleBuilder<CoreModuleBuilder> {
+    private Class<? extends BodyFactory> bodyFactory = DefaultBodyFactory.class;
+    private Class<? extends CookieManager> cookieManager = DefaultCookieManager.class;
+    private Class<? extends DispatchCallFactory> dispatchCallFactory = DefaultDispatchCallFactory.class;
+    private Class<? extends HeaderFactory> headerFactory = DefaultHeaderFactory.class;
+    private Class<? extends HttpParameterFactory> httpParameterFactory = DefaultHttpParameterFactory.class;
+    private Class<? extends RequestBuilderFactory> requestBuilderFactory = DefaultRequestBuilderFactory.class;
+    private Class<? extends ResponseDeserializer> responseDeserializer = DefaultResponseDeserializer.class;
+    private Class<? extends RestDispatch> restDispatch = DefaultRestDispatch.class;
+    private Class<? extends UriFactory> uriFactory = DefaultUriFactory.class;
+
+    public CoreModuleBuilder(BaseRestDispatchModuleBuilder<?> baseBuilder) {
+        super(baseBuilder);
+    }
+
+    public CoreModuleBuilder bodyFactory(Class<? extends BodyFactory> bodyFactory) {
+        this.bodyFactory = bodyFactory;
+        return self();
+    }
+
+    public CoreModuleBuilder cookieManager(Class<? extends CookieManager> cookieManager) {
+        this.cookieManager = cookieManager;
+        return self();
+    }
+
+    public CoreModuleBuilder dispatchCallFactory(Class<? extends DispatchCallFactory> dispatchCallFactory) {
+        this.dispatchCallFactory = dispatchCallFactory;
+        return self();
+    }
+
+    public CoreModuleBuilder headerFactory(Class<? extends HeaderFactory> headerFactory) {
+        this.headerFactory = headerFactory;
+        return self();
+    }
+
+    public CoreModuleBuilder httpParameterFactory(Class<? extends HttpParameterFactory> httpParameterFactory) {
+        this.httpParameterFactory = httpParameterFactory;
+        return self();
+    }
+
+    public CoreModuleBuilder requestBuilderFactory(Class<? extends RequestBuilderFactory> requestBuilderFactory) {
+        this.requestBuilderFactory = requestBuilderFactory;
+        return self();
+    }
+
+    public CoreModuleBuilder responseDeserializer(Class<? extends ResponseDeserializer> responseDeserializer) {
+        this.responseDeserializer = responseDeserializer;
+        return self();
+    }
+
+    public CoreModuleBuilder restDispatch(Class<? extends RestDispatch> restDispatch) {
+        this.restDispatch = restDispatch;
+        return self();
+    }
+
+    public CoreModuleBuilder uriFactory(Class<? extends UriFactory> uriFactory) {
+        this.uriFactory = uriFactory;
+        return self();
+    }
+
+    @Override
+    public CoreModule getCoreModule() {
+        return new CoreModule(this);
+    }
+
+    @Override
+    protected CoreModuleBuilder self() {
+        return this;
+    }
+
+    Class<? extends BodyFactory> getBodyFactory() {
+        return bodyFactory;
+    }
+
+    Class<? extends CookieManager> getCookieManager() {
+        return cookieManager;
+    }
+
+    Class<? extends DispatchCallFactory> getDispatchCallFactory() {
+        return dispatchCallFactory;
+    }
+
+    Class<? extends HeaderFactory> getHeaderFactory() {
+        return headerFactory;
+    }
+
+    Class<? extends HttpParameterFactory> getHttpParameterFactory() {
+        return httpParameterFactory;
+    }
+
+    Class<? extends RequestBuilderFactory> getRequestBuilderFactory() {
+        return requestBuilderFactory;
+    }
+
+    Class<? extends ResponseDeserializer> getResponseDeserializer() {
+        return responseDeserializer;
+    }
+
+    Class<? extends RestDispatch> getRestDispatch() {
+        return restDispatch;
+    }
+
+    Class<? extends UriFactory> getUriFactory() {
+        return uriFactory;
+    }
+}

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/DefaultRestDispatch.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/DefaultRestDispatch.java
@@ -26,11 +26,11 @@ import com.gwtplatform.dispatch.shared.DispatchRequest;
 /**
  * The default implementation for {@link com.gwtplatform.dispatch.rest.client.RestDispatch}.
  */
-public class RestDispatchAsync implements RestDispatch {
+public class DefaultRestDispatch implements RestDispatch {
     private final DispatchCallFactory callFactory;
 
     @Inject
-    protected RestDispatchAsync(
+    protected DefaultRestDispatch(
             DispatchCallFactory callFactory) {
         this.callFactory = callFactory;
     }

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/gin/BaseRestDispatchModuleBuilder.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/gin/BaseRestDispatchModuleBuilder.java
@@ -1,0 +1,210 @@
+/**
+ * Copyright 2015 ArcBees Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.gwtplatform.dispatch.rest.client.gin;
+
+import com.gwtplatform.dispatch.client.gin.AbstractDispatchAsyncModule.Builder;
+import com.gwtplatform.dispatch.rest.client.DefaultRestDispatchHooks;
+import com.gwtplatform.dispatch.rest.client.RestDispatchHooks;
+import com.gwtplatform.dispatch.rest.client.core.CoreModule;
+import com.gwtplatform.dispatch.rest.client.interceptor.DefaultRestInterceptorRegistry;
+import com.gwtplatform.dispatch.rest.client.interceptor.RestInterceptorRegistry;
+import com.gwtplatform.dispatch.rest.client.serialization.JsonSerialization;
+import com.gwtplatform.dispatch.rest.client.serialization.Serialization;
+import com.gwtplatform.dispatch.rest.shared.DateFormat;
+import com.gwtplatform.dispatch.rest.shared.HttpParameter.Type;
+
+/**
+ * A {@link RestDispatchAsyncModule} builder. Use it to configure constant parameters such as the default date format,
+ * the default timeout and more.
+ */
+public abstract class BaseRestDispatchModuleBuilder<B extends BaseRestDispatchModuleBuilder<B>> extends Builder<B> {
+    private String xsrfTokenHeaderName = RestDispatchAsyncModule.DEFAULT_XSRF_NAME;
+    private Class<? extends Serialization> serializationClass = JsonSerialization.class;
+    private int requestTimeoutMs;
+    private String defaultDateFormat = DateFormat.DEFAULT;
+    private RestParameterBindings globalHeaderParams = new RestParameterBindings();
+    private RestParameterBindings globalQueryParams = new RestParameterBindings();
+    private Class<? extends RestDispatchHooks> dispatchHooks = DefaultRestDispatchHooks.class;
+    private Class<? extends RestInterceptorRegistry> interceptorRegistry = DefaultRestInterceptorRegistry.class;
+
+    protected BaseRestDispatchModuleBuilder() {
+    }
+
+    protected BaseRestDispatchModuleBuilder(BaseRestDispatchModuleBuilder<?> copy) {
+        xsrfTokenHeaderName = copy.xsrfTokenHeaderName;
+        serializationClass = copy.serializationClass;
+        requestTimeoutMs = copy.requestTimeoutMs;
+        defaultDateFormat = copy.defaultDateFormat;
+        globalHeaderParams = copy.globalHeaderParams;
+        globalQueryParams = copy.globalQueryParams;
+        dispatchHooks = copy.dispatchHooks;
+        interceptorRegistry = copy.interceptorRegistry;
+    }
+
+    @Override
+    public RestDispatchAsyncModule build() {
+        return new RestDispatchAsyncModule(this);
+    }
+
+    /**
+     * Initiate the creation of a global header parameter that will be attached to all requests.
+     *
+     * @param key The key used for this parameter
+     *
+     * @return the parameter builder instance
+     */
+    public RestParameterBuilder<B> addGlobalHeaderParam(String key) {
+        return new RestParameterBuilder<B>(self(), Type.HEADER, globalHeaderParams, key);
+    }
+
+    /**
+     * Initiate the creation of a global query parameter that will be attached to all requests.
+     *
+     * @param key The key used for this parameter
+     *
+     * @return the parameter builder instance
+     */
+    public RestParameterBuilder<B> addGlobalQueryParam(String key) {
+        return new RestParameterBuilder<B>(self(), Type.QUERY, globalQueryParams, key);
+    }
+
+    /**
+     * Specify the pattern to use to format dates before they are sent to the end-point. The pattern must follow the
+     * rules defined by {@link com.google.gwt.i18n.shared.DateTimeFormat DateTimeFormat}.
+     * <p/>
+     * Default is {@link com.gwtplatform.dispatch.rest.shared.DateFormat#DEFAULT}.
+     *
+     * @param defaultDateFormat The pattern used to format dates.
+     *
+     * @return this {@link com.gwtplatform.dispatch.rest.client.gin.BaseRestDispatchModuleBuilder builder} object.
+     */
+    public B defaultDateFormat(String defaultDateFormat) {
+        this.defaultDateFormat = defaultDateFormat;
+        return self();
+    }
+
+    /**
+     * Specify the number of milliseconds to wait for a request to complete. If the timeout is reached, {@link
+     * com.google.gwt.user.client.rpc.AsyncCallback#onFailure(Throwable) AsyncCallback#onFailure(Throwable)} will be
+     * called. Default is <code>0</code>: no timeout.
+     *
+     * @param timeoutMs The maximum time to wait, in milliseconds, or {@code 0} for no timeout.
+     *
+     * @return this {@link com.gwtplatform.dispatch.rest.client.gin.BaseRestDispatchModuleBuilder builder} object.
+     */
+    public B requestTimeout(int timeoutMs) {
+        this.requestTimeoutMs = timeoutMs;
+        return self();
+    }
+
+    /**
+     * Specify the serialization implementation to use. Default is {@link com.gwtplatform.dispatch.rest.client
+     * .serialization.JsonSerialization}.
+     *
+     * @param serializationClass The {@link com.gwtplatform.dispatch.rest.client.serialization.Serialization}
+     * implementation to use.
+     *
+     * @return this {@link com.gwtplatform.dispatch.rest.client.gin.BaseRestDispatchModuleBuilder builder} object.
+     */
+    public B serialization(Class<? extends Serialization> serializationClass) {
+        this.serializationClass = serializationClass;
+        return self();
+    }
+
+    /**
+     * Specify the XSRF token header name.
+     *
+     * @deprecated See {@link #xsrfTokenHeaderName(String)}
+     */
+    @Deprecated
+    public B xcsrfTokenHeaderName(String xsrfTokenHeaderName) {
+        this.xsrfTokenHeaderName = xsrfTokenHeaderName;
+        return self();
+    }
+
+    /**
+     * Specify the XSRF token header name.
+     *
+     * @param xsrfTokenHeaderName The XSRF token header name.
+     *
+     * @return this {@link com.gwtplatform.dispatch.rest.client.gin.BaseRestDispatchModuleBuilder builder} object.
+     */
+    public B xsrfTokenHeaderName(String xsrfTokenHeaderName) {
+        this.xsrfTokenHeaderName = xsrfTokenHeaderName;
+        return self();
+    }
+
+    /**
+     * Supply your own implementation of {@link com.gwtplatform.dispatch.rest.client.RestDispatchHooks}. Default is
+     * {@link com.gwtplatform.dispatch.rest.client.DefaultRestDispatchHooks}
+     *
+     * @param dispatchHooks The {@link com.gwtplatform.dispatch.rest.client.RestDispatchHooks} implementation.
+     *
+     * @return this {@link com.gwtplatform.dispatch.rest.client.gin.BaseRestDispatchModuleBuilder} object.
+     */
+    public B dispatchHooks(Class<? extends RestDispatchHooks> dispatchHooks) {
+        this.dispatchHooks = dispatchHooks;
+        return self();
+    }
+
+    /**
+     * Specify an alternate REST interceptor registry.
+     *
+     * @param interceptorRegistry A {@link com.gwtplatform.dispatch.rest.client.interceptor.RestInterceptorRegistry
+     * RestInterceptorRegistry} class.
+     *
+     * @return this {@link com.gwtplatform.dispatch.rest.client.gin.BaseRestDispatchModuleBuilder builder} object.
+     */
+    public B interceptorRegistry(Class<? extends RestInterceptorRegistry> interceptorRegistry) {
+        this.interceptorRegistry = interceptorRegistry;
+        return self();
+    }
+
+    public abstract CoreModule getCoreModule();
+
+    String getDefaultDateFormat() {
+        return defaultDateFormat;
+    }
+
+    RestParameterBindings getGlobalHeaderParams() {
+        return globalHeaderParams;
+    }
+
+    RestParameterBindings getGlobalQueryParams() {
+        return globalQueryParams;
+    }
+
+    int getRequestTimeoutMs() {
+        return requestTimeoutMs;
+    }
+
+    Class<? extends Serialization> getSerializationClass() {
+        return serializationClass;
+    }
+
+    String getXsrfTokenHeaderName() {
+        return xsrfTokenHeaderName;
+    }
+
+    Class<? extends RestDispatchHooks> getDispatchHooks() {
+        return dispatchHooks;
+    }
+
+    Class<? extends RestInterceptorRegistry> getInterceptorRegistry() {
+        return interceptorRegistry;
+    }
+}

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/gin/RestDispatchAsyncModule.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/gin/RestDispatchAsyncModule.java
@@ -29,14 +29,14 @@ import com.gwtplatform.dispatch.rest.client.annotations.GlobalQueryParams;
 import com.gwtplatform.dispatch.rest.client.annotations.RequestTimeout;
 import com.gwtplatform.dispatch.rest.client.annotations.RestBinding;
 import com.gwtplatform.dispatch.rest.client.annotations.XsrfHeaderName;
-import com.gwtplatform.dispatch.rest.client.core.CoreModule;
 import com.gwtplatform.dispatch.rest.client.interceptor.RestInterceptorRegistry;
 import com.gwtplatform.dispatch.rest.client.serialization.Serialization;
 
 /**
- * An implementation of {@link AbstractDispatchAsyncModule} that uses REST calls. </p> This gin module provides provides
- * access to the {@link RestDispatch} singleton, which is used to make calls to the server over HTTP. This module
- * requires:
+ * An implementation of {@link AbstractDispatchAsyncModule} that binds classes used by a restful dispatch.
+ * <p/>
+ * This gin module provides access to the {@link RestDispatch} singleton, which is used to make calls to the server over
+ * HTTP.
  * <p/>
  * <b>You must</b> manually bind {@literal @}{@link com.gwtplatform.dispatch.rest.client.RestApplicationPath
  * RestApplicationPath} to point to your server API root path.
@@ -50,7 +50,7 @@ public class RestDispatchAsyncModule extends AbstractDispatchAsyncModule {
 
     public static final String DEFAULT_XSRF_NAME = "X-CSRF-Token";
 
-    private final RestDispatchAsyncModuleBuilder builder;
+    private final BaseRestDispatchModuleBuilder<?> builder;
     private final RestParameterBindingsSerializer bindingsSerializer = new RestParameterBindingsSerializer();
 
     /**
@@ -60,7 +60,7 @@ public class RestDispatchAsyncModule extends AbstractDispatchAsyncModule {
         this(new RestDispatchAsyncModuleBuilder());
     }
 
-    RestDispatchAsyncModule(RestDispatchAsyncModuleBuilder builder) {
+    RestDispatchAsyncModule(BaseRestDispatchModuleBuilder<?> builder) {
         super(builder, RestBinding.class);
 
         this.builder = builder;
@@ -70,7 +70,7 @@ public class RestDispatchAsyncModule extends AbstractDispatchAsyncModule {
     protected void configureDispatch() {
         // Common
         install(new CommonGinModule());
-        install(new CoreModule());
+        install(builder.getCoreModule());
 
         // Constants / Configurations
         // It's not possible to bind non-native type constants, so we must encode them at compile-time and decode them

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/gin/RestDispatchAsyncModuleBuilder.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/gin/RestDispatchAsyncModuleBuilder.java
@@ -16,153 +16,21 @@
 
 package com.gwtplatform.dispatch.rest.client.gin;
 
-import com.gwtplatform.dispatch.client.gin.AbstractDispatchAsyncModule.Builder;
-import com.gwtplatform.dispatch.rest.client.DefaultRestDispatchHooks;
-import com.gwtplatform.dispatch.rest.client.RestDispatchHooks;
-import com.gwtplatform.dispatch.rest.client.interceptor.DefaultRestInterceptorRegistry;
-import com.gwtplatform.dispatch.rest.client.interceptor.RestInterceptorRegistry;
-import com.gwtplatform.dispatch.rest.client.serialization.JsonSerialization;
-import com.gwtplatform.dispatch.rest.client.serialization.Serialization;
-import com.gwtplatform.dispatch.rest.shared.DateFormat;
-import com.gwtplatform.dispatch.rest.shared.HttpParameter.Type;
+import com.gwtplatform.dispatch.rest.client.core.CoreModule;
+import com.gwtplatform.dispatch.rest.client.core.CoreModuleBuilder;
 
 /**
- * A {@link RestDispatchAsyncModule} builder.
- * <p/>
- * The possible configurations are: <ul> <li>All configuration methods listed by {@link
- * com.gwtplatform.dispatch.client.gin.AbstractDispatchAsyncModule.Builder AbstractDispatchAsyncModule.Builder}</li>
- * <li>{@link #xsrfTokenHeaderName(String) XSRF Token Header Name}: A {@link
- * com.gwtplatform.dispatch.rest.client.annotations.XsrfHeaderName XsrfHeaderName}.
- * The default value is {@link RestDispatchAsyncModule#DEFAULT_XSRF_NAME}.</li> <li>{@link #serialization(Class)
- * Serialization Implementation}: A {@link Serialization} implementation. The default is {@link JsonSerialization}.</li>
- * <li>{@link #requestTimeout(int) Request timeout}: The number of milliseconds to wait for a request to complete. The
- * default value is 0 (no timeout).</li> </ul>
+ * {@inheritDoc}.
  */
-public class RestDispatchAsyncModuleBuilder extends Builder<RestDispatchAsyncModuleBuilder> {
-    private String xsrfTokenHeaderName = RestDispatchAsyncModule.DEFAULT_XSRF_NAME;
-    private Class<? extends Serialization> serializationClass = JsonSerialization.class;
-    private int requestTimeoutMs;
-    private String defaultDateFormat = DateFormat.DEFAULT;
-    private RestParameterBindings globalHeaderParams = new RestParameterBindings();
-    private RestParameterBindings globalQueryParams = new RestParameterBindings();
-    private Class<? extends RestDispatchHooks> dispatchHooks = DefaultRestDispatchHooks.class;
-    private Class<? extends RestInterceptorRegistry> interceptorRegistry = DefaultRestInterceptorRegistry.class;
-
-    /**
-     * Initiate the creation of a global header parameter that will be attached to all requests.
-     *
-     * @param key The key used for this parameter
-     *
-     * @return the parameter builder instance
-     */
-    public RestParameterBuilder addGlobalHeaderParam(String key) {
-        return new RestParameterBuilder(this, Type.HEADER, globalHeaderParams, key);
+public class RestDispatchAsyncModuleBuilder extends BaseRestDispatchModuleBuilder<RestDispatchAsyncModuleBuilder> {
+    public RestDispatchAsyncModuleBuilder() {
     }
 
     /**
-     * Initiate the creation of a global query parameter that will be attached to all requests.
-     *
-     * @param key The key used for this parameter
-     *
-     * @return the parameter builder instance
+     * Make methods for configuring core classes visible. Use and overwrite those classes to alter the core behaviors.
      */
-    public RestParameterBuilder addGlobalQueryParam(String key) {
-        return new RestParameterBuilder(this, Type.QUERY, globalQueryParams, key);
-    }
-
-    @Override
-    public RestDispatchAsyncModule build() {
-        return new RestDispatchAsyncModule(this);
-    }
-
-    /**
-     * Specify the pattern to use to format dates before they are sent to the end-point. The pattern must follow the
-     * rules defined by {@link com.google.gwt.i18n.shared.DateTimeFormat DateTimeFormat}.
-     * <p/>
-     * Default is {@link DateFormat#DEFAULT}.
-     *
-     * @param defaultDateFormat The pattern used to format dates.
-     *
-     * @return this {@link RestDispatchAsyncModuleBuilder builder} object.
-     */
-    public RestDispatchAsyncModuleBuilder defaultDateFormat(String defaultDateFormat) {
-        this.defaultDateFormat = defaultDateFormat;
-        return this;
-    }
-
-    /**
-     * Specify the number of milliseconds to wait for a request to complete. If the timeout is reached, {@link
-     * com.google.gwt.user.client.rpc.AsyncCallback#onFailure(Throwable) AsyncCallback#onFailure(Throwable)} will be
-     * called. Default is <code>0</code>: no timeout.
-     *
-     * @param timeoutMs The maximum time to wait, in milliseconds, or {@code 0} for no timeout.
-     *
-     * @return this {@link RestDispatchAsyncModuleBuilder builder} object.
-     */
-    public RestDispatchAsyncModuleBuilder requestTimeout(int timeoutMs) {
-        this.requestTimeoutMs = timeoutMs;
-        return this;
-    }
-
-    /**
-     * Specify the serialization implementation to use. Default is {@link JsonSerialization}.
-     *
-     * @param serializationClass The {@link Serialization} implementation to use.
-     *
-     * @return this {@link RestDispatchAsyncModuleBuilder builder} object.
-     */
-    public RestDispatchAsyncModuleBuilder serialization(Class<? extends Serialization> serializationClass) {
-        this.serializationClass = serializationClass;
-        return this;
-    }
-
-    /**
-     * Specify the XSRF token header name.
-     *
-     * @deprecated See {@link #xsrfTokenHeaderName(String)}
-     */
-    @Deprecated
-    public RestDispatchAsyncModuleBuilder xcsrfTokenHeaderName(String xsrfTokenHeaderName) {
-        this.xsrfTokenHeaderName = xsrfTokenHeaderName;
-        return this;
-    }
-
-    /**
-     * Specify the XSRF token header name.
-     *
-     * @param xsrfTokenHeaderName The XSRF token header name.
-     *
-     * @return this {@link RestDispatchAsyncModuleBuilder builder} object.
-     */
-    public RestDispatchAsyncModuleBuilder xsrfTokenHeaderName(String xsrfTokenHeaderName) {
-        this.xsrfTokenHeaderName = xsrfTokenHeaderName;
-        return this;
-    }
-
-    /**
-     * Supply your own implementation of {@link com.gwtplatform.dispatch.rest.client.RestDispatchHooks}. Default is
-     * {@link com.gwtplatform.dispatch.rest.client.DefaultRestDispatchHooks}
-     *
-     * @param dispatchHooks The {@link com.gwtplatform.dispatch.rest.client.RestDispatchHooks} implementation.
-     *
-     * @return this {@link RestDispatchAsyncModuleBuilder} object.
-     */
-    public RestDispatchAsyncModuleBuilder dispatchHooks(Class<? extends RestDispatchHooks> dispatchHooks) {
-        this.dispatchHooks = dispatchHooks;
-        return this;
-    }
-
-    /**
-     * Specify an alternate REST interceptor registry.
-     *
-     * @param interceptorRegistry A {@link RestInterceptorRegistry} class.
-     *
-     * @return this {@link RestDispatchAsyncModuleBuilder builder} object.
-     */
-    public RestDispatchAsyncModuleBuilder interceptorRegistry(
-            Class<? extends RestInterceptorRegistry> interceptorRegistry) {
-        this.interceptorRegistry = interceptorRegistry;
-        return this;
+    public CoreModuleBuilder core() {
+        return new CoreModuleBuilder(this);
     }
 
     @Override
@@ -170,35 +38,8 @@ public class RestDispatchAsyncModuleBuilder extends Builder<RestDispatchAsyncMod
         return this;
     }
 
-    String getDefaultDateFormat() {
-        return defaultDateFormat;
-    }
-
-    RestParameterBindings getGlobalHeaderParams() {
-        return globalHeaderParams;
-    }
-
-    RestParameterBindings getGlobalQueryParams() {
-        return globalQueryParams;
-    }
-
-    int getRequestTimeoutMs() {
-        return requestTimeoutMs;
-    }
-
-    Class<? extends Serialization> getSerializationClass() {
-        return serializationClass;
-    }
-
-    String getXsrfTokenHeaderName() {
-        return xsrfTokenHeaderName;
-    }
-
-    Class<? extends RestDispatchHooks> getDispatchHooks() {
-        return dispatchHooks;
-    }
-
-    Class<? extends RestInterceptorRegistry> getInterceptorRegistry() {
-        return interceptorRegistry;
+    @Override
+    public CoreModule getCoreModule() {
+        return core().getCoreModule();
     }
 }

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/gin/RestParameterBuilder.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/gin/RestParameterBuilder.java
@@ -28,15 +28,15 @@ import com.gwtplatform.dispatch.rest.shared.HttpParameter.Type;
 /**
  * Configure a global parameter to be sent with every HTTP requests.
  */
-public class RestParameterBuilder {
-    private final RestDispatchAsyncModuleBuilder moduleBuilder;
+public class RestParameterBuilder<B extends BaseRestDispatchModuleBuilder<B>> {
+    private final B moduleBuilder;
     private final Type type;
     private final RestParameterBindings target;
     private final String key;
     private final Set<HttpMethod> httpMethods = EnumSet.allOf(HttpMethod.class);
 
     RestParameterBuilder(
-            RestDispatchAsyncModuleBuilder moduleBuilder,
+            B moduleBuilder,
             Type type,
             RestParameterBindings target,
             String key) {
@@ -55,7 +55,7 @@ public class RestParameterBuilder {
      *
      * @return this builder instance.
      */
-    public RestParameterBuilder toHttpMethods(HttpMethod httpMethod, HttpMethod... otherHttpMethods) {
+    public RestParameterBuilder<B> toHttpMethods(HttpMethod httpMethod, HttpMethod... otherHttpMethods) {
         httpMethods.clear();
 
         httpMethods.add(httpMethod);
@@ -71,7 +71,7 @@ public class RestParameterBuilder {
      *
      * @return The module builder instance.
      */
-    public RestDispatchAsyncModuleBuilder withValue(String value) {
+    public B withValue(String value) {
         HttpParameter parameter = new ClientHttpParameter(type, key, value, null);
 
         for (HttpMethod httpMethod : httpMethods) {


### PR DESCRIPTION
I didn't want to pollute the main builder with methods for core bindings. `core()` will "make" those methods visible. Follow up for https://github.com/ArcBees/GWTP/pull/673#discussion_r23871733