### PR TITLE
Update gwt-jackson to 0.9.0

### DIFF
--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/serialization/JsonSerialization.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/serialization/JsonSerialization.java
@@ -37,9 +37,9 @@ public class JsonSerialization implements Serialization {
     JsonSerialization(JacksonMapperProvider jacksonMapperProvider) {
         this.jacksonMapperProvider = jacksonMapperProvider;
 
-        deserializationContext = new JsonDeserializationContext.Builder()
+        deserializationContext = JsonDeserializationContext.builder()
                 .failOnUnknownProperties(false);
-        serializationContext = new JsonSerializationContext.Builder();
+        serializationContext = JsonSerializationContext.builder();
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -248,7 +248,7 @@
         <gwt.version>2.7.0</gwt.version>
         <!-- when you update the gwt version please also update the dtds in all gwt.xml files -->
         <gin.version>2.1.2</gin.version>
-        <gwt-jackson.version>0.8.0</gwt-jackson.version>
+        <gwt-jackson.version>0.9.0</gwt-jackson.version>
 
         <!-- Server -->
         <jax-rs.version>1.1.1</jax-rs.version>


### PR DESCRIPTION
The old builder constructor is deprecated in favor of a static factory method. This way, the builder is created via `GWT.create` and it allows user to redefine it to change default options globally.