### PR TITLE
Add a fallback generator to overcome when the generated gin module is created too late

### DIFF
--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/annotations/Resource.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/annotations/Resource.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2015 ArcBees Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.gwtplatform.dispatch.rest.client.annotations;
+
+/**
+ * Extend this interface from your own resource interfaces if you can't use the generated GIN module. If your project
+ * can use the generated GIN module (usually those using the generated entry point and ginjector from MvpWithEntryPoint)
+ * don't need to do this.
+ */
+public interface Resource {
+}

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/CoreModule.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/CoreModule.java
@@ -40,5 +40,7 @@ public class CoreModule extends AbstractGinModule {
         bind(ResponseDeserializer.class).to(builder.getResponseDeserializer()).in(Singleton.class);
         bind(HttpParameterFactory.class).to(builder.getHttpParameterFactory()).in(Singleton.class);
         bind(RestDispatch.class).to(builder.getRestDispatch()).in(Singleton.class);
+
+        requestStaticInjection(StaticParametersFactory.class);
     }
 }

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/StaticParametersFactory.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/StaticParametersFactory.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2015 ArcBees Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.gwtplatform.dispatch.rest.client.core;
+
+import javax.inject.Inject;
+
+import com.gwtplatform.dispatch.rest.client.RestDispatch;
+import com.gwtplatform.dispatch.rest.client.annotations.DefaultDateFormat;
+import com.gwtplatform.dispatch.rest.client.core.parameters.HttpParameterFactory;
+
+/**
+ * Used internally by generated code to access various implementations bound by GIN. Injection could be used in
+ * generated code but because of changes introduced to the compiler in GWT 2.7, GIN generators may run before the
+ * generated GIN module is created and injection doesn't work in generated code.
+ * <p/>
+ * <strong>Don't use this class as it may change without notice.</strong>
+ */
+public class StaticParametersFactory {
+    @Inject
+    static RestDispatch restDispatch;
+    @Inject
+    static HttpParameterFactory httpParameterFactory;
+    @Inject
+    @DefaultDateFormat
+    static String defaultDateFormat;
+
+    public static RestDispatch getRestDispatch() {
+        return restDispatch;
+    }
+
+    public static HttpParameterFactory getHttpParameterFactory() {
+        return httpParameterFactory;
+    }
+
+    public static String getDefaultDateFormat() {
+        return defaultDateFormat;
+    }
+}

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/FallThroughGenerator.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/FallThroughGenerator.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2015 ArcBees Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.gwtplatform.dispatch.rest.rebind;
+
+import com.google.gwt.core.ext.Generator;
+import com.google.gwt.core.ext.GeneratorContext;
+import com.google.gwt.core.ext.TreeLogger;
+import com.google.gwt.core.ext.UnableToCompleteException;
+
+public class FallThroughGenerator extends Generator {
+    @Override
+    public String generate(TreeLogger logger, GeneratorContext context, String typeName)
+            throws UnableToCompleteException {
+        return typeName + "Impl";
+    }
+}

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/resource/AbstractResourceGenerator.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/resource/AbstractResourceGenerator.java
@@ -45,7 +45,8 @@ public abstract class AbstractResourceGenerator extends AbstractVelocityGenerato
     protected AbstractResourceGenerator(
             Logger logger,
             GeneratorContext context,
-            VelocityEngine velocityEngine, Set<MethodGenerator> methodGenerators) {
+            VelocityEngine velocityEngine,
+            Set<MethodGenerator> methodGenerators) {
         super(logger, context, velocityEngine);
 
         this.methodGenerators = methodGenerators;

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/resource/TopLevelResourceGenerator.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/resource/TopLevelResourceGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/resources/com/gwtplatform/dispatch/rest/DispatchRest.gwt.xml
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/resources/com/gwtplatform/dispatch/rest/DispatchRest.gwt.xml
@@ -27,4 +27,12 @@
     <generate-with class="com.gwtplatform.dispatch.rest.rebind.DispatchRestIncrementalGenerator">
         <when-type-is class="com.gwtplatform.dispatch.rest.client.DispatchRestEntryPoint"/>
     </generate-with>
+
+    <!-- Fallbacks -->
+    <generate-with class="com.gwtplatform.dispatch.rest.rebind.FallThroughGenerator">
+        <when-type-assignable class="com.gwtplatform.dispatch.rest.client.annotations.Resource"/>
+    </generate-with>
+    <generate-with class="com.gwtplatform.dispatch.rest.rebind.FallThroughGenerator">
+        <when-type-is class="com.gwtplatform.dispatch.rest.client.serialization.JacksonMapperProvider"/>
+    </generate-with>
 </module>

--- a/gwtp-core/gwtp-dispatch-rest/src/main/resources/com/gwtplatform/dispatch/rest/rebind/resource/Resource.vm
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/resources/com/gwtplatform/dispatch/rest/rebind/resource/Resource.vm
@@ -1,8 +1,6 @@
 package $package;
 
-import javax.inject.Inject;
-
-import com.gwtplatform.dispatch.rest.client.annotations.DefaultDateFormat;
+import com.gwtplatform.dispatch.rest.client.core.StaticParametersFactory;
 import com.gwtplatform.dispatch.rest.client.core.parameters.HttpParameterFactory;
 #foreach ($import in $imports)
 import $import;
@@ -12,12 +10,9 @@ public class $impl implements $resourceType {
     private final HttpParameterFactory httpParameterFactory;
     private final String defaultDateFormat;
 
-    @Inject
-    ${impl}(
-            HttpParameterFactory httpParameterFactory,
-            @DefaultDateFormat String defaultDateFormat) {
-        this.defaultDateFormat = defaultDateFormat;
-        this.httpParameterFactory = httpParameterFactory;
+    ${impl}() {
+        this.defaultDateFormat = StaticParametersFactory.getDefaultDateFormat();
+        this.httpParameterFactory = StaticParametersFactory.getHttpParameterFactory();
     }
 
 #foreach ($method in $methods)

--- a/gwtp-core/gwtp-dispatch-rest/src/main/resources/com/gwtplatform/dispatch/rest/rebind/serialization/JacksonMapperProvider.vm
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/resources/com/gwtplatform/dispatch/rest/rebind/serialization/JacksonMapperProvider.vm
@@ -3,16 +3,29 @@ package $package;
 import javax.inject.Inject;
 import javax.inject.Provider;
 
+import com.github.nmorel.gwtjackson.client.ObjectMapper;
 import com.google.inject.TypeLiteral;
+import com.google.gwt.core.client.GWT;
 #if (!$definitions.isEmpty())
 import ${package}.mappers.*;
 #end
 
 public class $impl extends AbstractJacksonMapperProvider {
-    @Inject
-    $impl(#foreach ($definition in $definitions)Provider<$definition.getParameterizedClassName()> ${definition.className}Provider#commaIfNeeded($definitions)$lf#end) {
+    $impl() {
 #foreach ($definition in $definitions)
-        registerProvider("$definition.serializableType.getParameterizedQualifiedSourceName()", ${definition.className}Provider);
+        registerProvider("$definition.serializableType.getParameterizedQualifiedSourceName()",
+                new Provider<ObjectMapper<?>>() {
+                    private ObjectMapper<?> mapper;
+
+                    @Override
+                    public ObjectMapper<?> get() {
+                        if (mapper == null){
+                            mapper = (ObjectMapper<?>) GWT.create(${definition.className}.class);
+                        }
+
+                        return mapper;
+                    }
+                });
 #end
     }
 }


### PR DESCRIPTION
Resolve #614, #650

This PR is a workaround so that generated resources can be used when the underlying GIN module is generated _after_ GIN generators run.

Because of how GWT generators work with assignable types, using this workaround requires resources to extend `com.gwtplatform.dispatch.rest.client.annotations.Resource`. Projects that can use the generated GIN module (usually those using the generated entry point and ginjector from MvpWithEntryPoint) don't need to do this.

I'm thinking more and more about apt... Even if it means losing gwt code-gen tools.