### PR TITLE
Use rebind rule only in client code for legacy slot converter.

### DIFF
--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/LegacySlotConvertor.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/LegacySlotConvertor.java
@@ -23,17 +23,16 @@ import java.util.logging.Logger;
 import com.google.gwt.core.shared.GWT;
 
 public class LegacySlotConvertor {
-    static String WARNING_MESSAGE = "Warning: You're using an untyped slot!\n"
+    static final String WARNING_MESSAGE = "Warning: You're using an untyped slot!\n"
             + "Untyped slots are dangerous! Please upgrade your slots using\n"
             + "the Arcbee's easy upgrade tool at\n"
             + "https://arcbees.github.io/gwtp-slot-upgrader";
 
     private static final Logger LOGGER = Logger.getLogger(LegacySlotConvertor.class.getName());
 
-    private static LegacySlotConvertor INSTANCE = GWT.create(LegacySlotConvertor.class);
+    private static LegacySlotConvertor INSTANCE;
 
-    private Map<Object, LegacySlot> legacySlotMap =
-            new HashMap<Object, LegacySlot>();
+    private final Map<Object, LegacySlot> legacySlotMap = new HashMap<Object, LegacySlot>();
 
     protected LegacySlot get(Object slot) {
         if (!legacySlotMap.containsKey(slot)) {
@@ -44,6 +43,14 @@ public class LegacySlotConvertor {
     }
 
     public static LegacySlot convert(Object slot) {
+        if (INSTANCE == null) {
+            if (GWT.isScript()) {
+                INSTANCE = GWT.create(LegacySlotConvertor.class);
+            } else {
+                INSTANCE = new LegacySlotConvertor();
+            }
+        }
+
         return INSTANCE.get(slot);
     }
 }

--- a/gwtp-core/gwtp-mvp-client/src/main/resources/com/gwtplatform/mvp/Mvp.gwt.xml
+++ b/gwtp-core/gwtp-mvp-client/src/main/resources/com/gwtplatform/mvp/Mvp.gwt.xml
@@ -21,8 +21,7 @@
     <!-- Specify the paths for translatable code                    -->
     <source path='client' excludes="**/*Test.java,**/*TestSuite.java,**/*TestUtil.java"/>
 
-    <!-- gin.ginjector is set to a default value, no other value must be set for Ginjector generation -->
-    <!-- if another value is set, it must point to a valid manual Ginjector class -->
+    <!-- gin.ginjector is set to a default value, no other value must be set for Ginjector generation --><!-- if another value is set, it must point to a valid manual Ginjector class -->
     <define-configuration-property name="gin.ginjector" is-multi-valued="false"/>
     <set-configuration-property name="gin.ginjector" value="com.gwtplatform.mvp.client.ClientGinjector"/>
 
@@ -30,10 +29,10 @@
     <define-configuration-property name="gin.ginjector.extensions" is-multi-valued="true"/>
     <set-configuration-property name="gin.ginjector.extensions" value=""/>
 
-   <!-- 
-     optional comma separated list of annotation classes which can be added to widget presenter for
-     declaration in ginjector 
-   -->
+    <!--
+      optional comma separated list of annotation classes which can be added to widget presenter for
+      declaration in ginjector
+    -->
     <define-configuration-property name="gin.ginjector.annotation" is-multi-valued="true"/>
     <set-configuration-property name="gin.ginjector.annotation" value=""/>
 
@@ -65,25 +64,25 @@
     </generate-with>
 
     <replace-with class="com.google.gwt.place.shared.PlaceHistoryHandler.DefaultHistorian">
-        <when-type-assignable class="com.google.gwt.place.shared.PlaceHistoryHandler.Historian" />
+        <when-type-assignable class="com.google.gwt.place.shared.PlaceHistoryHandler.Historian"/>
     </replace-with>
-    
-    <!-- 
+
+    <!--
     When set to true gwtp projects will crash in dev mode when a legacy slot is used!
     Use this to be confident that no deprecated slot methods are used.
-    It will not change the behavior of compiled code. 
+    It will not change the behavior of compiled code.
     -->
     <define-property values="true, false" name="gwtp.crashOnLegacySlot"/>
     <set-property name="gwtp.crashOnLegacySlot" value="false"/>
-    
+
     <replace-with class="com.gwtplatform.mvp.client.presenter.slots.LegacySlotConvertor">
-    	<when-type-is class="com.gwtplatform.mvp.client.presenter.slots.LegacySlotConvertor"/>
-  	</replace-with>
-  	
-  	<replace-with class="com.gwtplatform.mvp.client.presenter.slots.CrashingLegacySlotConvertor">
-    	<when-type-is class="com.gwtplatform.mvp.client.presenter.slots.LegacySlotConvertor"/>
-    	<all>
-    		<when-property-is name="gwtp.crashOnLegacySlot" value="true"/>
-    	</all>
-  	</replace-with>
+        <when-type-is class="com.gwtplatform.mvp.client.presenter.slots.LegacySlotConvertor"/>
+    </replace-with>
+
+    <replace-with class="com.gwtplatform.mvp.client.presenter.slots.CrashingLegacySlotConvertor">
+        <when-type-is class="com.gwtplatform.mvp.client.presenter.slots.LegacySlotConvertor"/>
+        <all>
+            <when-property-is name="gwtp.crashOnLegacySlot" value="true"/>
+        </all>
+    </replace-with>
 </module>


### PR DESCRIPTION
The converter is used from presenters. The `GWT.create()` ends up breaking unit tests, so we only use it when running in javascript.