### PR TITLE
Update copyrights to a single leading *

### DIFF
--- a/gwtp-core/gwtp-clients-common/src/main/java/com/gwtplatform/common/client/ClientUrlUtils.java
+++ b/gwtp-core/gwtp-clients-common/src/main/java/com/gwtplatform/common/client/ClientUrlUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-clients-common/src/main/java/com/gwtplatform/common/client/CodeSplitBundleProvider.java
+++ b/gwtp-core/gwtp-clients-common/src/main/java/com/gwtplatform/common/client/CodeSplitBundleProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-clients-common/src/main/java/com/gwtplatform/common/client/CodeSplitProvider.java
+++ b/gwtp-core/gwtp-clients-common/src/main/java/com/gwtplatform/common/client/CodeSplitProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-clients-common/src/main/java/com/gwtplatform/common/client/CommonGinModule.java
+++ b/gwtp-core/gwtp-clients-common/src/main/java/com/gwtplatform/common/client/CommonGinModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-clients-common/src/main/java/com/gwtplatform/common/client/IndirectProvider.java
+++ b/gwtp-core/gwtp-clients-common/src/main/java/com/gwtplatform/common/client/IndirectProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-clients-common/src/main/java/com/gwtplatform/common/client/ProviderBundle.java
+++ b/gwtp-core/gwtp-clients-common/src/main/java/com/gwtplatform/common/client/ProviderBundle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-clients-common/src/main/java/com/gwtplatform/common/client/StandardProvider.java
+++ b/gwtp-core/gwtp-clients-common/src/main/java/com/gwtplatform/common/client/StandardProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-clients-common/src/main/java/com/gwtplatform/common/rebind/Dependency.java
+++ b/gwtp-core/gwtp-clients-common/src/main/java/com/gwtplatform/common/rebind/Dependency.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-clients-common/src/main/java/com/gwtplatform/common/rebind/DependencyImpl.java
+++ b/gwtp-core/gwtp-clients-common/src/main/java/com/gwtplatform/common/rebind/DependencyImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-clients-common/src/main/java/com/gwtplatform/common/rebind/Logger.java
+++ b/gwtp-core/gwtp-clients-common/src/main/java/com/gwtplatform/common/rebind/Logger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-clients-common/src/main/java/com/gwtplatform/common/rebind/VersionInspectorLinker.java
+++ b/gwtp-core/gwtp-clients-common/src/main/java/com/gwtplatform/common/rebind/VersionInspectorLinker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-clients-common/src/main/java/com/gwtplatform/common/shared/UrlUtils.java
+++ b/gwtp-core/gwtp-clients-common/src/main/java/com/gwtplatform/common/shared/UrlUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-crawler/src/main/java/com/gwtplatform/crawler/server/CrawlFilter.java
+++ b/gwtp-core/gwtp-crawler/src/main/java/com/gwtplatform/crawler/server/CrawlFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-crawler/src/main/java/com/gwtplatform/crawler/server/ServiceKey.java
+++ b/gwtp-core/gwtp-crawler/src/main/java/com/gwtplatform/crawler/server/ServiceKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-crawler/src/main/java/com/gwtplatform/crawler/server/ServiceUrl.java
+++ b/gwtp-core/gwtp-crawler/src/main/java/com/gwtplatform/crawler/server/ServiceUrl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/CallbackDispatchRequest.java
+++ b/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/CallbackDispatchRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/CompletedDispatchRequest.java
+++ b/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/CompletedDispatchRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/DefaultCallbackDispatchRequest.java
+++ b/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/DefaultCallbackDispatchRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/DefaultExceptionHandler.java
+++ b/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/DefaultExceptionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/DefaultSecurityCookieAccessor.java
+++ b/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/DefaultSecurityCookieAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/DelegatingAsyncCallback.java
+++ b/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/DelegatingAsyncCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/DelegatingCallbackDispatchRequest.java
+++ b/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/DelegatingCallbackDispatchRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/DelegatingDispatchRequest.java
+++ b/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/DelegatingDispatchRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/DispatchCall.java
+++ b/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/DispatchCall.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/ExceptionHandler.java
+++ b/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/ExceptionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/GwtHttpDispatchRequest.java
+++ b/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/GwtHttpDispatchRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/OldDelegatingAsyncCallback.java
+++ b/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/OldDelegatingAsyncCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/actionhandler/AbstractClientActionHandler.java
+++ b/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/actionhandler/AbstractClientActionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/actionhandler/ClientActionHandler.java
+++ b/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/actionhandler/ClientActionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/actionhandler/ClientActionHandlerMismatchException.java
+++ b/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/actionhandler/ClientActionHandlerMismatchException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/actionhandler/ClientActionHandlerRegistry.java
+++ b/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/actionhandler/ClientActionHandlerRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/actionhandler/DefaultClientActionHandlerRegistry.java
+++ b/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/actionhandler/DefaultClientActionHandlerRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/actionhandler/ExecuteCommand.java
+++ b/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/actionhandler/ExecuteCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/actionhandler/UndoCommand.java
+++ b/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/actionhandler/UndoCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/actionhandler/caching/AbstractCachingClientActionHandler.java
+++ b/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/actionhandler/caching/AbstractCachingClientActionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/actionhandler/caching/ActionCachingHandler.java
+++ b/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/actionhandler/caching/ActionCachingHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/actionhandler/caching/Cache.java
+++ b/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/actionhandler/caching/Cache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/actionhandler/caching/DefaultCacheImpl.java
+++ b/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/actionhandler/caching/DefaultCacheImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/gin/AbstractDispatchAsyncModule.java
+++ b/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/gin/AbstractDispatchAsyncModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/interceptor/AbstractInterceptor.java
+++ b/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/interceptor/AbstractInterceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/interceptor/ExecuteCommand.java
+++ b/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/interceptor/ExecuteCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/interceptor/Interceptor.java
+++ b/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/interceptor/Interceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/interceptor/InterceptorMismatchException.java
+++ b/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/interceptor/InterceptorMismatchException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/interceptor/InterceptorRegistry.java
+++ b/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/interceptor/InterceptorRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-common-shared/src/main/java/com/gwtplatform/dispatch/shared/ActionException.java
+++ b/gwtp-core/gwtp-dispatch-common-shared/src/main/java/com/gwtplatform/dispatch/shared/ActionException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-common-shared/src/main/java/com/gwtplatform/dispatch/shared/DispatchRequest.java
+++ b/gwtp-core/gwtp-dispatch-common-shared/src/main/java/com/gwtplatform/dispatch/shared/DispatchRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-common-shared/src/main/java/com/gwtplatform/dispatch/shared/HasSecured.java
+++ b/gwtp-core/gwtp-dispatch-common-shared/src/main/java/com/gwtplatform/dispatch/shared/HasSecured.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-common-shared/src/main/java/com/gwtplatform/dispatch/shared/SecurityCookie.java
+++ b/gwtp-core/gwtp-dispatch-common-shared/src/main/java/com/gwtplatform/dispatch/shared/SecurityCookie.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-common-shared/src/main/java/com/gwtplatform/dispatch/shared/SecurityCookieAccessor.java
+++ b/gwtp-core/gwtp-dispatch-common-shared/src/main/java/com/gwtplatform/dispatch/shared/SecurityCookieAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-common-shared/src/main/java/com/gwtplatform/dispatch/shared/TypedAction.java
+++ b/gwtp-core/gwtp-dispatch-common-shared/src/main/java/com/gwtplatform/dispatch/shared/TypedAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest-shared/src/main/java/com/gwtplatform/dispatch/rest/shared/ContentType.java
+++ b/gwtp-core/gwtp-dispatch-rest-shared/src/main/java/com/gwtplatform/dispatch/rest/shared/ContentType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest-shared/src/main/java/com/gwtplatform/dispatch/rest/shared/DateFormat.java
+++ b/gwtp-core/gwtp-dispatch-rest-shared/src/main/java/com/gwtplatform/dispatch/rest/shared/DateFormat.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest-shared/src/main/java/com/gwtplatform/dispatch/rest/shared/HttpMethod.java
+++ b/gwtp-core/gwtp-dispatch-rest-shared/src/main/java/com/gwtplatform/dispatch/rest/shared/HttpMethod.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest-shared/src/main/java/com/gwtplatform/dispatch/rest/shared/HttpParameter.java
+++ b/gwtp-core/gwtp-dispatch-rest-shared/src/main/java/com/gwtplatform/dispatch/rest/shared/HttpParameter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest-shared/src/main/java/com/gwtplatform/dispatch/rest/shared/NoXsrfHeader.java
+++ b/gwtp-core/gwtp-dispatch-rest-shared/src/main/java/com/gwtplatform/dispatch/rest/shared/NoXsrfHeader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest-shared/src/main/java/com/gwtplatform/dispatch/rest/shared/RestAction.java
+++ b/gwtp-core/gwtp-dispatch-rest-shared/src/main/java/com/gwtplatform/dispatch/rest/shared/RestAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest-shared/src/test/java/com/gwtplatform/dispatch/rest/shared/ContentTypeTest.java
+++ b/gwtp-core/gwtp-dispatch-rest-shared/src/test/java/com/gwtplatform/dispatch/rest/shared/ContentTypeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/DefaultRestDispatchHooks.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/DefaultRestDispatchHooks.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/DispatchRestEntryPoint.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/DispatchRestEntryPoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/RestApplicationPath.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/RestApplicationPath.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/RestCallback.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/RestCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/RestDispatch.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/RestDispatch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/RestDispatchHooks.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/RestDispatchHooks.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/annotations/DefaultDateFormat.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/annotations/DefaultDateFormat.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/annotations/GlobalHeaderParams.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/annotations/GlobalHeaderParams.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/annotations/GlobalQueryParams.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/annotations/GlobalQueryParams.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/annotations/RequestTimeout.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/annotations/RequestTimeout.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/annotations/RestBinding.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/annotations/RestBinding.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/annotations/XsrfHeaderName.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/annotations/XsrfHeaderName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/codegen/AbstractDispatchRestEntryPoint.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/codegen/AbstractDispatchRestEntryPoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/codegen/AbstractRestAction.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/codegen/AbstractRestAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/BodyFactory.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/BodyFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/CookieManager.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/CookieManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/CoreModule.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/CoreModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/CoreModuleBuilder.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/CoreModuleBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/DefaultCookieManager.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/DefaultCookieManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/DefaultDispatchCallFactory.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/DefaultDispatchCallFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/DefaultHeaderFactory.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/DefaultHeaderFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/DefaultRequestBuilderFactory.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/DefaultRequestBuilderFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/DefaultRestDispatch.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/DefaultRestDispatch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/DefaultUriFactory.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/DefaultUriFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/DispatchCallFactory.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/DispatchCallFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/HeaderFactory.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/HeaderFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/HttpRequestBuilderFactory.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/HttpRequestBuilderFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/RequestBuilderFactory.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/RequestBuilderFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/ResponseDeserializer.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/ResponseDeserializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/ResponseWrapper.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/ResponseWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/RestDispatchCall.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/RestDispatchCall.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/UriFactory.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/UriFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/parameters/ClientHttpParameter.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/parameters/ClientHttpParameter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/parameters/CollectionSupportedParameter.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/parameters/CollectionSupportedParameter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/parameters/CookieParameter.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/parameters/CookieParameter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/parameters/DefaultHttpParameterFactory.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/parameters/DefaultHttpParameterFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/parameters/FormParameter.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/parameters/FormParameter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/parameters/HeaderParameter.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/parameters/HeaderParameter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/parameters/HttpParameterFactory.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/parameters/HttpParameterFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/parameters/MatrixParameter.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/parameters/MatrixParameter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/parameters/PathParameter.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/parameters/PathParameter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/parameters/QueryParameter.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/parameters/QueryParameter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/gin/BaseRestDispatchModuleBuilder.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/gin/BaseRestDispatchModuleBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/gin/RestDispatchAsyncModule.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/gin/RestDispatchAsyncModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/gin/RestDispatchAsyncModuleBuilder.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/gin/RestDispatchAsyncModuleBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/gin/RestParameterBindings.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/gin/RestParameterBindings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/gin/RestParameterBindingsSerializer.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/gin/RestParameterBindingsSerializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/gin/RestParameterBuilder.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/gin/RestParameterBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/interceptor/AbstractRestInterceptor.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/interceptor/AbstractRestInterceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/interceptor/DefaultRestInterceptorRegistry.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/interceptor/DefaultRestInterceptorRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/interceptor/DuplicateInterceptorContextException.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/interceptor/DuplicateInterceptorContextException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/interceptor/InterceptorContext.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/interceptor/InterceptorContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/interceptor/InterceptorContextHttpParameter.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/interceptor/InterceptorContextHttpParameter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/interceptor/InterceptorContextRestAction.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/interceptor/InterceptorContextRestAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/interceptor/RestInterceptedAsyncCallback.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/interceptor/RestInterceptedAsyncCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/interceptor/RestInterceptor.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/interceptor/RestInterceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/interceptor/RestInterceptorRegistry.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/interceptor/RestInterceptorRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/serialization/AbstractJacksonMapperProvider.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/serialization/AbstractJacksonMapperProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/serialization/JacksonMapperProvider.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/serialization/JacksonMapperProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/serialization/JsonSerialization.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/serialization/JsonSerialization.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/serialization/Serialization.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/serialization/Serialization.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/serialization/SerializationException.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/serialization/SerializationException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/serialization/SerializationModule.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/serialization/SerializationModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/serialization/SerializedValue.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/serialization/SerializedValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/emul/javax/ws/rs/core/Cookie.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/emul/javax/ws/rs/core/Cookie.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/emul/javax/ws/rs/core/MediaType.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/emul/javax/ws/rs/core/MediaType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/emul/javax/ws/rs/core/NewCookie.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/emul/javax/ws/rs/core/NewCookie.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/AbstractGenerator.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/AbstractGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/AbstractVelocityGenerator.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/AbstractVelocityGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/DispatchRestGenerator.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/DispatchRestGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/DispatchRestIncrementalGenerator.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/DispatchRestIncrementalGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/DispatchRestRebindModule.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/DispatchRestRebindModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/GeneratorWithInput.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/GeneratorWithInput.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/GeneratorWithoutInput.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/GeneratorWithoutInput.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/HasPriority.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/HasPriority.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/HttpVerb.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/HttpVerb.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/Parameter.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/Parameter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/action/ActionContext.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/action/ActionContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/action/ActionDefinition.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/action/ActionDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/action/ActionGenerator.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/action/ActionGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/action/ActionMethodDefinition.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/action/ActionMethodDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/action/ActionMethodGenerator.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/action/ActionMethodGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/action/ActionModule.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/action/ActionModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/action/RestActionGenerator.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/action/RestActionGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/entrypoint/DefaultEntryPointGenerator.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/entrypoint/DefaultEntryPointGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/entrypoint/EntryPointGenerator.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/entrypoint/EntryPointGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/entrypoint/EntryPointModule.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/entrypoint/EntryPointModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/extension/EmptyExtension.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/extension/EmptyExtension.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/extension/ExtensionContext.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/extension/ExtensionContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/extension/ExtensionGenerator.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/extension/ExtensionGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/extension/ExtensionModule.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/extension/ExtensionModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/extension/ExtensionPoint.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/extension/ExtensionPoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/gin/DefaultGinModuleGenerator.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/gin/DefaultGinModuleGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/gin/GinModule.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/gin/GinModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/gin/GinModuleGenerator.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/gin/GinModuleGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/parameter/CookieParamValueResolver.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/parameter/CookieParamValueResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/parameter/FormParamValueResolver.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/parameter/FormParamValueResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/parameter/HeaderParamValueResolver.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/parameter/HeaderParamValueResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/parameter/HttpParamValueResolver.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/parameter/HttpParamValueResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/parameter/HttpParameter.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/parameter/HttpParameter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/parameter/HttpParameterFactory.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/parameter/HttpParameterFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/parameter/HttpParameterType.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/parameter/HttpParameterType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/parameter/MatrixParamValueResolver.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/parameter/MatrixParamValueResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/parameter/PathParamValueResolver.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/parameter/PathParamValueResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/parameter/QueryParamValueResolver.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/parameter/QueryParamValueResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/resource/AbstractMethodGenerator.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/resource/AbstractMethodGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/resource/AbstractResourceGenerator.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/resource/AbstractResourceGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/resource/MethodContext.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/resource/MethodContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/resource/MethodDefinition.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/resource/MethodDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/resource/MethodGenerator.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/resource/MethodGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/resource/ResourceContext.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/resource/ResourceContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/resource/ResourceDefinition.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/resource/ResourceDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/resource/ResourceGenerator.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/resource/ResourceGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/resource/ResourceModule.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/resource/ResourceModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/serialization/JacksonMapperGenerator.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/serialization/JacksonMapperGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/serialization/JacksonMapperProviderGenerator.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/serialization/JacksonMapperProviderGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/serialization/SerializationContext.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/serialization/SerializationContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/serialization/SerializationDefinition.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/serialization/SerializationDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/serialization/SerializationGenerator.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/serialization/SerializationGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/serialization/SerializationModule.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/serialization/SerializationModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/subresource/SubResourceContext.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/subresource/SubResourceContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/subresource/SubResourceDefinition.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/subresource/SubResourceDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/subresource/SubResourceGenerator.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/subresource/SubResourceGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/subresource/SubResourceMethodDefinition.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/subresource/SubResourceMethodDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/subresource/SubResourceMethodGenerator.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/subresource/SubResourceMethodGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/subresource/SubResourceModule.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/subresource/SubResourceModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/utils/Arrays.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/utils/Arrays.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/utils/ClassDefinition.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/utils/ClassDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/utils/ClassNameGenerator.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/utils/ClassNameGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/utils/ContentTypeResolver.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/utils/ContentTypeResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/utils/Generators.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/utils/Generators.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/utils/JPrimitives.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/utils/JPrimitives.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/utils/Logger.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/utils/Logger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/utils/PathResolver.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/utils/PathResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/DefaultRequestBuilderFactoryTest.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/DefaultRequestBuilderFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/RestDispatchCallTest.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/RestDispatchCallTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/codegen/AbstractRestActionTest.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/codegen/AbstractRestActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/core/DefaultBodyFactoryTest.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/core/DefaultBodyFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/core/DefaultCookieManagerTest.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/core/DefaultCookieManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/core/DefaultHeaderFactoryTest.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/core/DefaultHeaderFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/core/DefaultResponseDeserializerTest.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/core/DefaultResponseDeserializerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/core/DefaultUriFactoryTest.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/core/DefaultUriFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/core/parameters/CookieParameterTest.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/core/parameters/CookieParameterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/core/parameters/DefaultHttpParameterFactoryTest.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/core/parameters/DefaultHttpParameterFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/core/parameters/FormParameterTest.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/core/parameters/FormParameterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/core/parameters/HeaderParameterTest.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/core/parameters/HeaderParameterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/core/parameters/MatrixParameterTest.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/core/parameters/MatrixParameterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/core/parameters/PathParameterTest.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/core/parameters/PathParameterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/core/parameters/QueryParameterTest.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/core/parameters/QueryParameterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/interceptor/RestInterceptorRegistryTest.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/interceptor/RestInterceptorRegistryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/interceptor/SampleRestInterceptor.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/interceptor/SampleRestInterceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/serialization/RestParameterBindingsSerializerTest.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/serialization/RestParameterBindingsSerializerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/testutils/ExposedRestAction.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/testutils/ExposedRestAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/testutils/MockHttpParameterFactory.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/testutils/MockHttpParameterFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/testutils/RuntimeDelegateStub.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/testutils/RuntimeDelegateStub.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/testutils/SecuredRestAction.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/testutils/SecuredRestAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/testutils/UnsecuredRestAction.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/testutils/UnsecuredRestAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/rebind/parameter/CookieParamValueResolverTest.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/rebind/parameter/CookieParamValueResolverTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/rebind/parameter/MatrixParamValueResolverTest.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/rebind/parameter/MatrixParamValueResolverTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/rebind/utils/ContentTypeResolverTest.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/rebind/utils/ContentTypeResolverTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/rebind/utils/JPrimitivesTest.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/rebind/utils/JPrimitivesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/client/AbstractDispatchAsync.java
+++ b/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/client/AbstractDispatchAsync.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/client/DefaultDispatchAsync.java
+++ b/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/client/DefaultDispatchAsync.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/client/PhoneGapDispatchAsync.java
+++ b/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/client/PhoneGapDispatchAsync.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/client/RemoteServerUrl.java
+++ b/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/client/RemoteServerUrl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/client/RpcDispatchAsync.java
+++ b/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/client/RpcDispatchAsync.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/client/gin/DispatchAsyncModule.java
+++ b/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/client/gin/DispatchAsyncModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/client/gin/PhoneGapDispatchAsyncModule.java
+++ b/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/client/gin/PhoneGapDispatchAsyncModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/rpc/client/DefaultRpcDispatchCallFactory.java
+++ b/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/rpc/client/DefaultRpcDispatchCallFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/rpc/client/DefaultRpcDispatchHooks.java
+++ b/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/rpc/client/DefaultRpcDispatchHooks.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/rpc/client/PhoneGapDispatchAsync.java
+++ b/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/rpc/client/PhoneGapDispatchAsync.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/rpc/client/RemoteServerUrl.java
+++ b/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/rpc/client/RemoteServerUrl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/rpc/client/RpcBinding.java
+++ b/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/rpc/client/RpcBinding.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/rpc/client/RpcDispatchAsync.java
+++ b/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/rpc/client/RpcDispatchAsync.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/rpc/client/RpcDispatchCallFactory.java
+++ b/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/rpc/client/RpcDispatchCallFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/rpc/client/RpcDispatchExecuteCall.java
+++ b/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/rpc/client/RpcDispatchExecuteCall.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/rpc/client/RpcDispatchHooks.java
+++ b/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/rpc/client/RpcDispatchHooks.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/rpc/client/RpcDispatchUndoCall.java
+++ b/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/rpc/client/RpcDispatchUndoCall.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/rpc/client/gin/PhoneGapDispatchAsyncModule.java
+++ b/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/rpc/client/gin/PhoneGapDispatchAsyncModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/rpc/client/gin/RpcDispatchAsyncModule.java
+++ b/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/rpc/client/gin/RpcDispatchAsyncModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/rpc/client/interceptor/AbstractRpcInterceptor.java
+++ b/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/rpc/client/interceptor/AbstractRpcInterceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/rpc/client/interceptor/DefaultRpcInterceptorRegistry.java
+++ b/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/rpc/client/interceptor/DefaultRpcInterceptorRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/rpc/client/interceptor/RpcInterceptedAsyncCallback.java
+++ b/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/rpc/client/interceptor/RpcInterceptedAsyncCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/rpc/client/interceptor/RpcInterceptor.java
+++ b/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/rpc/client/interceptor/RpcInterceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/rpc/client/interceptor/RpcInterceptorRegistry.java
+++ b/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/rpc/client/interceptor/RpcInterceptorRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/rpc/client/interceptor/UndoCommand.java
+++ b/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/rpc/client/interceptor/UndoCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/rpc/client/interceptor/caching/AbstractCachingRpcInterceptor.java
+++ b/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/rpc/client/interceptor/caching/AbstractCachingRpcInterceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/rpc/client/interceptor/caching/Cache.java
+++ b/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/rpc/client/interceptor/caching/Cache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/rpc/client/interceptor/caching/CachingInterceptor.java
+++ b/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/rpc/client/interceptor/caching/CachingInterceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/rpc/client/interceptor/caching/DefaultCacheImpl.java
+++ b/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/rpc/client/interceptor/caching/DefaultCacheImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-client/src/test/java/com/gwtplatform/dispatch/rpc/client/interceptor/AbstractRpcInterceptorTest.java
+++ b/gwtp-core/gwtp-dispatch-rpc-client/src/test/java/com/gwtplatform/dispatch/rpc/client/interceptor/AbstractRpcInterceptorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-guice/src/main/java/com/gwtplatform/dispatch/rpc/server/guice/DispatchImpl.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-guice/src/main/java/com/gwtplatform/dispatch/rpc/server/guice/DispatchImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-guice/src/main/java/com/gwtplatform/dispatch/rpc/server/guice/DispatchModule.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-guice/src/main/java/com/gwtplatform/dispatch/rpc/server/guice/DispatchModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-guice/src/main/java/com/gwtplatform/dispatch/rpc/server/guice/DispatchServiceImpl.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-guice/src/main/java/com/gwtplatform/dispatch/rpc/server/guice/DispatchServiceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-guice/src/main/java/com/gwtplatform/dispatch/rpc/server/guice/GuiceBeanProvider.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-guice/src/main/java/com/gwtplatform/dispatch/rpc/server/guice/GuiceBeanProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-guice/src/main/java/com/gwtplatform/dispatch/rpc/server/guice/HandlerModule.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-guice/src/main/java/com/gwtplatform/dispatch/rpc/server/guice/HandlerModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-guice/src/main/java/com/gwtplatform/dispatch/rpc/server/guice/HttpSessionSecurityCookieFilter.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-guice/src/main/java/com/gwtplatform/dispatch/rpc/server/guice/HttpSessionSecurityCookieFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-guice/src/main/java/com/gwtplatform/dispatch/rpc/server/guice/RandomSecurityCookieFilter.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-guice/src/main/java/com/gwtplatform/dispatch/rpc/server/guice/RandomSecurityCookieFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-guice/src/main/java/com/gwtplatform/dispatch/rpc/server/guice/SecureRandomSingleton.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-guice/src/main/java/com/gwtplatform/dispatch/rpc/server/guice/SecureRandomSingleton.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-guice/src/main/java/com/gwtplatform/dispatch/rpc/server/guice/actionhandlervalidator/ActionHandlerValidatorLinker.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-guice/src/main/java/com/gwtplatform/dispatch/rpc/server/guice/actionhandlervalidator/ActionHandlerValidatorLinker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-guice/src/main/java/com/gwtplatform/dispatch/rpc/server/guice/actionhandlervalidator/EagerActionHandlerValidatorRegistryImpl.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-guice/src/main/java/com/gwtplatform/dispatch/rpc/server/guice/actionhandlervalidator/EagerActionHandlerValidatorRegistryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-guice/src/main/java/com/gwtplatform/dispatch/rpc/server/guice/actionhandlervalidator/LazyActionHandlerValidatorRegistryImpl.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-guice/src/main/java/com/gwtplatform/dispatch/rpc/server/guice/actionhandlervalidator/LazyActionHandlerValidatorRegistryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-guice/src/main/java/com/gwtplatform/dispatch/rpc/server/guice/actionvalidator/DefaultActionValidator.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-guice/src/main/java/com/gwtplatform/dispatch/rpc/server/guice/actionvalidator/DefaultActionValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-guice/src/main/java/com/gwtplatform/dispatch/rpc/server/guice/request/DefaultRequestProvider.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-guice/src/main/java/com/gwtplatform/dispatch/rpc/server/guice/request/DefaultRequestProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-guice/src/main/java/com/gwtplatform/dispatch/server/guice/DispatchImpl.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-guice/src/main/java/com/gwtplatform/dispatch/server/guice/DispatchImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-guice/src/main/java/com/gwtplatform/dispatch/server/guice/DispatchModule.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-guice/src/main/java/com/gwtplatform/dispatch/server/guice/DispatchModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-guice/src/main/java/com/gwtplatform/dispatch/server/guice/DispatchServiceImpl.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-guice/src/main/java/com/gwtplatform/dispatch/server/guice/DispatchServiceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-guice/src/main/java/com/gwtplatform/dispatch/server/guice/GuiceBeanProvider.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-guice/src/main/java/com/gwtplatform/dispatch/server/guice/GuiceBeanProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-guice/src/main/java/com/gwtplatform/dispatch/server/guice/HandlerModule.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-guice/src/main/java/com/gwtplatform/dispatch/server/guice/HandlerModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-guice/src/main/java/com/gwtplatform/dispatch/server/guice/HttpSessionSecurityCookieFilter.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-guice/src/main/java/com/gwtplatform/dispatch/server/guice/HttpSessionSecurityCookieFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-guice/src/main/java/com/gwtplatform/dispatch/server/guice/RandomSecurityCookieFilter.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-guice/src/main/java/com/gwtplatform/dispatch/server/guice/RandomSecurityCookieFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-guice/src/main/java/com/gwtplatform/dispatch/server/guice/SecureRandomSingleton.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-guice/src/main/java/com/gwtplatform/dispatch/server/guice/SecureRandomSingleton.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-guice/src/main/java/com/gwtplatform/dispatch/server/guice/actionhandlervalidator/ActionHandlerValidatorLinker.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-guice/src/main/java/com/gwtplatform/dispatch/server/guice/actionhandlervalidator/ActionHandlerValidatorLinker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-guice/src/main/java/com/gwtplatform/dispatch/server/guice/actionhandlervalidator/EagerActionHandlerValidatorRegistryImpl.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-guice/src/main/java/com/gwtplatform/dispatch/server/guice/actionhandlervalidator/EagerActionHandlerValidatorRegistryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-guice/src/main/java/com/gwtplatform/dispatch/server/guice/actionhandlervalidator/LazyActionHandlerValidatorRegistryImpl.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-guice/src/main/java/com/gwtplatform/dispatch/server/guice/actionhandlervalidator/LazyActionHandlerValidatorRegistryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-guice/src/main/java/com/gwtplatform/dispatch/server/guice/actionvalidator/DefaultActionValidator.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-guice/src/main/java/com/gwtplatform/dispatch/server/guice/actionvalidator/DefaultActionValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-guice/src/main/java/com/gwtplatform/dispatch/server/guice/request/DefaultRequestProvider.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-guice/src/main/java/com/gwtplatform/dispatch/server/guice/request/DefaultRequestProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-guice/src/test/java/com/gwtplatform/dispatch/rpc/server/ActionExceptionThrownByHandler.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-guice/src/test/java/com/gwtplatform/dispatch/rpc/server/ActionExceptionThrownByHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-guice/src/test/java/com/gwtplatform/dispatch/rpc/server/ActionExceptionThrownByValidator.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-guice/src/test/java/com/gwtplatform/dispatch/rpc/server/ActionExceptionThrownByValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-guice/src/test/java/com/gwtplatform/dispatch/rpc/server/ActionThrownByHandlerTest.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-guice/src/test/java/com/gwtplatform/dispatch/rpc/server/ActionThrownByHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-guice/src/test/java/com/gwtplatform/dispatch/rpc/server/ActionThrownByValidatorTest.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-guice/src/test/java/com/gwtplatform/dispatch/rpc/server/ActionThrownByValidatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-guice/src/test/java/com/gwtplatform/dispatch/rpc/server/ActionValidatorThatThrows.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-guice/src/test/java/com/gwtplatform/dispatch/rpc/server/ActionValidatorThatThrows.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-guice/src/test/java/com/gwtplatform/dispatch/rpc/server/HandlerThatThrowsActionException.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-guice/src/test/java/com/gwtplatform/dispatch/rpc/server/HandlerThatThrowsActionException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-guice/src/test/java/com/gwtplatform/dispatch/rpc/server/ServiceModule.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-guice/src/test/java/com/gwtplatform/dispatch/rpc/server/ServiceModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-guice/src/test/java/com/gwtplatform/dispatch/rpc/server/SomeAction.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-guice/src/test/java/com/gwtplatform/dispatch/rpc/server/SomeAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-guice/src/test/java/com/gwtplatform/dispatch/rpc/server/guice/ActionModule.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-guice/src/test/java/com/gwtplatform/dispatch/rpc/server/guice/ActionModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/rpc/server/spring/AnnotatedActionBeandHandlerRegistrator.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/rpc/server/spring/AnnotatedActionBeandHandlerRegistrator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/rpc/server/spring/DispatchImpl.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/rpc/server/spring/DispatchImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/rpc/server/spring/DispatchModule.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/rpc/server/spring/DispatchModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/rpc/server/spring/DispatchServiceImpl.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/rpc/server/spring/DispatchServiceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/rpc/server/spring/HandlerModule.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/rpc/server/spring/HandlerModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/rpc/server/spring/HttpSessionSecurityCookieFilter.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/rpc/server/spring/HttpSessionSecurityCookieFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/rpc/server/spring/LoggerFactoryBean.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/rpc/server/spring/LoggerFactoryBean.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/rpc/server/spring/RandomSecurityCookieFilter.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/rpc/server/spring/RandomSecurityCookieFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/rpc/server/spring/SecureRandomSingleton.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/rpc/server/spring/SecureRandomSingleton.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/rpc/server/spring/SpringBeanProvider.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/rpc/server/spring/SpringBeanProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/rpc/server/spring/actionhandlervalidator/ActionHandlerValidatorLinker.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/rpc/server/spring/actionhandlervalidator/ActionHandlerValidatorLinker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/rpc/server/spring/actionhandlervalidator/EagerActionHandlerValidatorRegistryImpl.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/rpc/server/spring/actionhandlervalidator/EagerActionHandlerValidatorRegistryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/rpc/server/spring/actionhandlervalidator/LazyActionHandlerValidatorRegistryImpl.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/rpc/server/spring/actionhandlervalidator/LazyActionHandlerValidatorRegistryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/rpc/server/spring/actionvalidator/DefaultActionValidator.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/rpc/server/spring/actionvalidator/DefaultActionValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/rpc/server/spring/annotation/RegisterActionHandler.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/rpc/server/spring/annotation/RegisterActionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/rpc/server/spring/configuration/DefaultModule.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/rpc/server/spring/configuration/DefaultModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/rpc/server/spring/request/DefaultRequestProvider.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/rpc/server/spring/request/DefaultRequestProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/rpc/server/spring/utils/RequestProvider.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/rpc/server/spring/utils/RequestProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/rpc/server/spring/utils/SpringUtils.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/rpc/server/spring/utils/SpringUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/server/spring/AnnotatedActionBeandHandlerRegistrator.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/server/spring/AnnotatedActionBeandHandlerRegistrator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/server/spring/DispatchImpl.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/server/spring/DispatchImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/server/spring/DispatchModule.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/server/spring/DispatchModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/server/spring/DispatchServiceImpl.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/server/spring/DispatchServiceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/server/spring/HandlerModule.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/server/spring/HandlerModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/server/spring/HttpSessionSecurityCookieFilter.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/server/spring/HttpSessionSecurityCookieFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/server/spring/LoggerFactoryBean.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/server/spring/LoggerFactoryBean.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/server/spring/RandomSecurityCookieFilter.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/server/spring/RandomSecurityCookieFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/server/spring/SecureRandomSingleton.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/server/spring/SecureRandomSingleton.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/server/spring/SpringBeanProvider.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/server/spring/SpringBeanProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/server/spring/actionhandlervalidator/ActionHandlerValidatorLinker.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/server/spring/actionhandlervalidator/ActionHandlerValidatorLinker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/server/spring/actionhandlervalidator/EagerActionHandlerValidatorRegistryImpl.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/server/spring/actionhandlervalidator/EagerActionHandlerValidatorRegistryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/server/spring/actionhandlervalidator/LazyActionHandlerValidatorRegistryImpl.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/server/spring/actionhandlervalidator/LazyActionHandlerValidatorRegistryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/server/spring/actionvalidator/DefaultActionValidator.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/server/spring/actionvalidator/DefaultActionValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/server/spring/annotation/RegisterActionHandler.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/server/spring/annotation/RegisterActionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/server/spring/configuration/DefaultModule.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/server/spring/configuration/DefaultModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/server/spring/request/DefaultRequestProvider.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/server/spring/request/DefaultRequestProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/server/spring/utils/RequestProvider.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/server/spring/utils/RequestProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/server/spring/utils/SpringUtils.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/server/spring/utils/SpringUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-spring/src/test/java/com/gwtplatform/dispatch/rpc/server/actionhandler/TestAnnotatedActionHandler.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-spring/src/test/java/com/gwtplatform/dispatch/rpc/server/actionhandler/TestAnnotatedActionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-spring/src/test/java/com/gwtplatform/dispatch/rpc/server/spring/ActionModule.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-spring/src/test/java/com/gwtplatform/dispatch/rpc/server/spring/ActionModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-spring/src/test/java/com/gwtplatform/dispatch/rpc/server/spring/ActionSpringTest.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-spring/src/test/java/com/gwtplatform/dispatch/rpc/server/spring/ActionSpringTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server-spring/src/test/java/com/gwtplatform/dispatch/rpc/shared/action/TestAnnotatedAction.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-spring/src/test/java/com/gwtplatform/dispatch/rpc/shared/action/TestAnnotatedAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/rpc/server/AbstractDispatchImpl.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/rpc/server/AbstractDispatchImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/rpc/server/AbstractDispatchServiceImpl.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/rpc/server/AbstractDispatchServiceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/rpc/server/AbstractHttpSessionSecurityCookieFilter.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/rpc/server/AbstractHttpSessionSecurityCookieFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/rpc/server/AbstractRandomSecurityCookieFilter.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/rpc/server/AbstractRandomSecurityCookieFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/rpc/server/Dispatch.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/rpc/server/Dispatch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/rpc/server/ExecutionContext.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/rpc/server/ExecutionContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/rpc/server/RequestProvider.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/rpc/server/RequestProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/rpc/server/Utils.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/rpc/server/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/rpc/server/actionhandler/AbstractActionHandler.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/rpc/server/actionhandler/AbstractActionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/rpc/server/actionhandler/ActionHandler.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/rpc/server/actionhandler/ActionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/rpc/server/actionhandler/ActionResult.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/rpc/server/actionhandler/ActionResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/rpc/server/actionhandler/BatchActionHandler.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/rpc/server/actionhandler/BatchActionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/rpc/server/actionhandlervalidator/AbstractEagerActionHandlerValidatorRegistryImpl.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/rpc/server/actionhandlervalidator/AbstractEagerActionHandlerValidatorRegistryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/rpc/server/actionhandlervalidator/ActionHandlerValidatorClass.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/rpc/server/actionhandlervalidator/ActionHandlerValidatorClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/rpc/server/actionhandlervalidator/ActionHandlerValidatorInstance.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/rpc/server/actionhandlervalidator/ActionHandlerValidatorInstance.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/rpc/server/actionhandlervalidator/ActionHandlerValidatorLinkerHelper.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/rpc/server/actionhandlervalidator/ActionHandlerValidatorLinkerHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/rpc/server/actionhandlervalidator/ActionHandlerValidatorMap.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/rpc/server/actionhandlervalidator/ActionHandlerValidatorMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/rpc/server/actionhandlervalidator/ActionHandlerValidatorMapImpl.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/rpc/server/actionhandlervalidator/ActionHandlerValidatorMapImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/rpc/server/actionhandlervalidator/ActionHandlerValidatorRegistry.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/rpc/server/actionhandlervalidator/ActionHandlerValidatorRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/rpc/server/actionhandlervalidator/EagerActionHandlerValidatorRegistry.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/rpc/server/actionhandlervalidator/EagerActionHandlerValidatorRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/rpc/server/actionhandlervalidator/LazyActionHandlerValidatorRegistry.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/rpc/server/actionhandlervalidator/LazyActionHandlerValidatorRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/rpc/server/actionvalidator/AbstractDefaultActionValidator.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/rpc/server/actionvalidator/AbstractDefaultActionValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/rpc/server/actionvalidator/ActionValidator.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/rpc/server/actionvalidator/ActionValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/server/AbstractDispatchImpl.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/server/AbstractDispatchImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/server/AbstractDispatchServiceImpl.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/server/AbstractDispatchServiceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/server/AbstractHttpSessionSecurityCookieFilter.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/server/AbstractHttpSessionSecurityCookieFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/server/AbstractRandomSecurityCookieFilter.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/server/AbstractRandomSecurityCookieFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/server/Dispatch.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/server/Dispatch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/server/ExecutionContext.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/server/ExecutionContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/server/RequestProvider.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/server/RequestProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/server/Utils.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/server/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/server/actionhandler/AbstractActionHandler.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/server/actionhandler/AbstractActionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/server/actionhandler/ActionHandler.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/server/actionhandler/ActionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/server/actionhandler/ActionResult.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/server/actionhandler/ActionResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/server/actionhandler/BatchActionHandler.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/server/actionhandler/BatchActionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/server/actionhandlervalidator/AbstractEagerActionHandlerValidatorRegistryImpl.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/server/actionhandlervalidator/AbstractEagerActionHandlerValidatorRegistryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/server/actionhandlervalidator/ActionHandlerValidatorClass.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/server/actionhandlervalidator/ActionHandlerValidatorClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/server/actionhandlervalidator/ActionHandlerValidatorInstance.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/server/actionhandlervalidator/ActionHandlerValidatorInstance.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/server/actionhandlervalidator/ActionHandlerValidatorLinkerHelper.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/server/actionhandlervalidator/ActionHandlerValidatorLinkerHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/server/actionhandlervalidator/ActionHandlerValidatorMap.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/server/actionhandlervalidator/ActionHandlerValidatorMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/server/actionhandlervalidator/ActionHandlerValidatorMapImpl.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/server/actionhandlervalidator/ActionHandlerValidatorMapImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/server/actionhandlervalidator/ActionHandlerValidatorRegistry.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/server/actionhandlervalidator/ActionHandlerValidatorRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/server/actionhandlervalidator/EagerActionHandlerValidatorRegistry.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/server/actionhandlervalidator/EagerActionHandlerValidatorRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/server/actionhandlervalidator/LazyActionHandlerValidatorRegistry.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/server/actionhandlervalidator/LazyActionHandlerValidatorRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/server/actionvalidator/AbstractDefaultActionValidator.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/server/actionvalidator/AbstractDefaultActionValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/server/actionvalidator/ActionValidator.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/server/actionvalidator/ActionValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/rpc/shared/AbstractSimpleResult.java
+++ b/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/rpc/shared/AbstractSimpleResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/rpc/shared/AbstractUpdateResult.java
+++ b/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/rpc/shared/AbstractUpdateResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/rpc/shared/Action.java
+++ b/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/rpc/shared/Action.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/rpc/shared/ActionImpl.java
+++ b/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/rpc/shared/ActionImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/rpc/shared/BatchAction.java
+++ b/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/rpc/shared/BatchAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/rpc/shared/BatchResult.java
+++ b/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/rpc/shared/BatchResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/rpc/shared/DispatchAsync.java
+++ b/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/rpc/shared/DispatchAsync.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/rpc/shared/DispatchService.java
+++ b/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/rpc/shared/DispatchService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/rpc/shared/DispatchServiceAsync.java
+++ b/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/rpc/shared/DispatchServiceAsync.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/rpc/shared/MultipleResult.java
+++ b/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/rpc/shared/MultipleResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/rpc/shared/NoResult.java
+++ b/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/rpc/shared/NoResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/rpc/shared/Result.java
+++ b/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/rpc/shared/Result.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -22,16 +22,16 @@ import com.google.gwt.user.client.rpc.IsSerializable;
 
 /**
  * A marker interface for {@link Action} results.<p>
- * 
+ *
  * Result is used instead of Serializable to prevent
  * the RPC mechanism from generating a serializer for all classes
  * that implement Serializable.
- * 
+ *
  * @see
  * {@link SimpleResult}<br>
  * {@link MultipleResult}<br>
  * {@link NoResult}<br>
- * 
+ *
  */
 public interface Result extends IsSerializable, Serializable {
 }

--- a/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/rpc/shared/ServiceException.java
+++ b/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/rpc/shared/ServiceException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/rpc/shared/SimpleResult.java
+++ b/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/rpc/shared/SimpleResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/rpc/shared/UnsecuredActionImpl.java
+++ b/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/rpc/shared/UnsecuredActionImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/rpc/shared/UnsupportedActionException.java
+++ b/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/rpc/shared/UnsupportedActionException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/shared/AbstractSimpleResult.java
+++ b/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/shared/AbstractSimpleResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/shared/AbstractUpdateResult.java
+++ b/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/shared/AbstractUpdateResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/shared/Action.java
+++ b/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/shared/Action.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/shared/ActionImpl.java
+++ b/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/shared/ActionImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/shared/BatchAction.java
+++ b/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/shared/BatchAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/shared/BatchResult.java
+++ b/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/shared/BatchResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/shared/DispatchAsync.java
+++ b/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/shared/DispatchAsync.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/shared/DispatchService.java
+++ b/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/shared/DispatchService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/shared/DispatchServiceAsync.java
+++ b/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/shared/DispatchServiceAsync.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/shared/MultipleResult.java
+++ b/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/shared/MultipleResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/shared/NoResult.java
+++ b/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/shared/NoResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/shared/Result.java
+++ b/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/shared/Result.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/shared/ServiceException.java
+++ b/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/shared/ServiceException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/shared/SimpleResult.java
+++ b/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/shared/SimpleResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/shared/UnsecuredActionImpl.java
+++ b/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/shared/UnsecuredActionImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/shared/UnsupportedActionException.java
+++ b/gwtp-core/gwtp-dispatch-rpc-shared/src/main/java/com/gwtplatform/dispatch/shared/UnsupportedActionException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-test/src/main/java/com/gwtplatform/dispatch/rpc/server/ActionTestBase.java
+++ b/gwtp-core/gwtp-dispatch-rpc-test/src/main/java/com/gwtplatform/dispatch/rpc/server/ActionTestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-test/src/main/java/com/gwtplatform/dispatch/rpc/server/actionhandler/TestActionHandler.java
+++ b/gwtp-core/gwtp-dispatch-rpc-test/src/main/java/com/gwtplatform/dispatch/rpc/server/actionhandler/TestActionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-test/src/main/java/com/gwtplatform/dispatch/rpc/shared/action/TestAction.java
+++ b/gwtp-core/gwtp-dispatch-rpc-test/src/main/java/com/gwtplatform/dispatch/rpc/shared/action/TestAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-dispatch-rpc-test/src/main/java/com/gwtplatform/dispatch/rpc/shared/action/TestResult.java
+++ b/gwtp-core/gwtp-dispatch-rpc-test/src/main/java/com/gwtplatform/dispatch/rpc/shared/action/TestResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/ApplicationController.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/ApplicationController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/AutobindDisable.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/AutobindDisable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/Bootstrapper.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/Bootstrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/ChangeTabEvent.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/ChangeTabEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/ChangeTabHandler.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/ChangeTabHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/DefaultBootstrapper.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/DefaultBootstrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/DelayedBind.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/DelayedBind.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/DelayedBindRegistry.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/DelayedBindRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/HandlerContainer.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/HandlerContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/HandlerContainerImpl.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/HandlerContainerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/HasHandlerContainer.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/HasHandlerContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/HasPopupSlot.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/HasPopupSlot.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/HasSlots.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/HasSlots.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/HasUiHandlers.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/HasUiHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/PopupView.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/PopupView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/PopupViewCloseHandler.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/PopupViewCloseHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/PopupViewImpl.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/PopupViewImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/PopupViewWithUiHandlers.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/PopupViewWithUiHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/PreBootstrapper.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/PreBootstrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/Presenter.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/Presenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/PresenterWidget.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/PresenterWidget.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -287,7 +287,7 @@ public abstract class PresenterWidget<V extends View> extends HandlerContainerIm
     * {@link UmbrellaException} and then re-thrown after all handlers have
     * completed. An exception thrown by a handler will not prevent other handlers
     * from executing.
-    * 
+    *
     * @param event the event
     */
     public void fireEvent(Event<?> event) {

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/RequestTabsEvent.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/RequestTabsEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/RequestTabsHandler.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/RequestTabsHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/RootPresenter.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/RootPresenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/Tab.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/Tab.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/TabContainerPresenter.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/TabContainerPresenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/TabData.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/TabData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/TabDataBasic.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/TabDataBasic.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/TabPanel.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/TabPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/TabView.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/TabView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/UiHandlers.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/UiHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/View.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/View.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/ViewImpl.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/ViewImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/ViewWithUiHandlers.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/ViewWithUiHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/annotations/ChangeTab.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/annotations/ChangeTab.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/annotations/ContentSlot.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/annotations/ContentSlot.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/annotations/CustomProvider.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/annotations/CustomProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/annotations/DefaultGatekeeper.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/annotations/DefaultGatekeeper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/annotations/DefaultPlace.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/annotations/DefaultPlace.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/annotations/ErrorPlace.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/annotations/ErrorPlace.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/annotations/GaAccount.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/annotations/GaAccount.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/annotations/GatekeeperParams.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/annotations/GatekeeperParams.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/annotations/NameToken.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/annotations/NameToken.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/annotations/NoGatekeeper.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/annotations/NoGatekeeper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/annotations/ProxyCodeSplit.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/annotations/ProxyCodeSplit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/annotations/ProxyCodeSplitBundle.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/annotations/ProxyCodeSplitBundle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/annotations/ProxyEvent.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/annotations/ProxyEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/annotations/ProxyStandard.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/annotations/ProxyStandard.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/annotations/RequestTabs.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/annotations/RequestTabs.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/annotations/TabInfo.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/annotations/TabInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/annotations/Title.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/annotations/Title.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/annotations/TitleFunction.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/annotations/TitleFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/annotations/UnauthorizedPlace.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/annotations/UnauthorizedPlace.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/annotations/UseGatekeeper.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/annotations/UseGatekeeper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/gin/AbstractPresenterModule.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/gin/AbstractPresenterModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/gin/PresenterSetupModule.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/gin/PresenterSetupModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/googleanalytics/GoogleAnalytics.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/googleanalytics/GoogleAnalytics.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/googleanalytics/GoogleAnalyticsImpl.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/googleanalytics/GoogleAnalyticsImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/googleanalytics/GoogleAnalyticsNavigationTracker.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/googleanalytics/GoogleAnalyticsNavigationTracker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/CrashingLegacySlotConvertor.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/CrashingLegacySlotConvertor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/IsSingleSlot.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/IsSingleSlot.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/IsSlot.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/IsSlot.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/LegacySlot.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/LegacySlot.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/LegacySlotConvertor.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/LegacySlotConvertor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/MultiSlot.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/MultiSlot.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/NestedSlot.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/NestedSlot.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/OrderedSlot.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/OrderedSlot.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/PermanentSlot.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/PermanentSlot.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/PopupSlot.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/PopupSlot.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/RemovableSlot.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/RemovableSlot.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/SingleSlot.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/SingleSlot.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/Slot.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/presenter/slots/Slot.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/AsyncCallFailEvent.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/AsyncCallFailEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/AsyncCallFailHandler.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/AsyncCallFailHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/AsyncCallStartEvent.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/AsyncCallStartEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/AsyncCallStartHandler.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/AsyncCallStartHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/AsyncCallSucceedEvent.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/AsyncCallSucceedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/AsyncCallSucceedHandler.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/AsyncCallSucceedHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/DefaultPlaceManager.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/DefaultPlaceManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/Gatekeeper.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/Gatekeeper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/GatekeeperWithParams.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/GatekeeperWithParams.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/GetPlaceTitleEvent.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/GetPlaceTitleEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/GetPlaceTitleHandler.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/GetPlaceTitleHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/LockInteractionEvent.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/LockInteractionEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/LockInteractionHandler.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/LockInteractionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/ManualRevealCallback.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/ManualRevealCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/NavigationEvent.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/NavigationEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/NavigationHandler.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/NavigationHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/NavigationRefusedEvent.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/NavigationRefusedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/NavigationRefusedHandler.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/NavigationRefusedHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/NonLeafTabContentProxy.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/NonLeafTabContentProxy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/NonLeafTabContentProxyImpl.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/NonLeafTabContentProxyImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/NotifyingAsyncCallback.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/NotifyingAsyncCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/Place.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/Place.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/PlaceImpl.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/PlaceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/PlaceManager.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/PlaceManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/PlaceManagerImpl.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/PlaceManagerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/PlaceRequestInternalEvent.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/PlaceRequestInternalEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/PlaceRequestInternalHandler.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/PlaceRequestInternalHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/PlaceWithGatekeeper.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/PlaceWithGatekeeper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/PlaceWithGatekeeperWithParams.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/PlaceWithGatekeeperWithParams.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/Proxy.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/Proxy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/ProxyImpl.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/ProxyImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/ProxyPlace.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/ProxyPlace.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/ProxyPlaceAbstract.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/ProxyPlaceAbstract.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/ProxyPlaceImpl.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/ProxyPlaceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/ProxyRaw.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/ProxyRaw.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/ResetPresentersEvent.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/ResetPresentersEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/ResetPresentersHandler.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/ResetPresentersHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/RevealContentEvent.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/RevealContentEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/RevealContentHandler.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/RevealContentHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/RevealRootContentEvent.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/RevealRootContentEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/RevealRootContentHandler.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/RevealRootContentHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/RevealRootLayoutContentEvent.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/RevealRootLayoutContentEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/RevealRootLayoutContentHandler.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/RevealRootLayoutContentHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/RevealRootPopupContentEvent.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/RevealRootPopupContentEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -28,7 +28,7 @@ import com.gwtplatform.mvp.client.PresenterWidget;
  * parent.<br/>
  * Use this type of event to reveal popup content that should get added at the
  * root of the presenter hierarchy.
- * 
+ *
  * @see RevealContentEvent
  * @see RevealRootContentEvent
  * @see RevealRootLayoutContentEvent
@@ -53,7 +53,7 @@ public final class RevealRootPopupContentEvent extends
     /**
      * Fires a {@link RevealRootPopupContentEvent} into a source that has access
      * to an {@link com.google.web.bindery.event.shared.EventBus}.
-     * 
+     *
      * @param source
      *            The source that fires this event ({@link HasHandlers}).
      * @param content
@@ -68,7 +68,7 @@ public final class RevealRootPopupContentEvent extends
     /**
      * Fires a {@link RevealRootPopupContentEvent} into a source that has access
      * to an {@link com.google.web.bindery.event.shared.EventBus}.
-     * 
+     *
      * @param source
      *            The source that fires this event ({@link HasHandlers}).
      * @param content

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/RevealRootPopupContentHandler.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/RevealRootPopupContentHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/SetPlaceTitleHandler.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/SetPlaceTitleHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/TabContentProxy.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/TabContentProxy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/TabContentProxyPlace.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/TabContentProxyPlace.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/TabContentProxyPlaceImpl.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/proxy/TabContentProxyPlaceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/view/CenterPopupPositioner.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/view/CenterPopupPositioner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/view/PopupPositioner.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/view/PopupPositioner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/view/RelativeToWidgetPopupPositioner.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/view/RelativeToWidgetPopupPositioner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -29,7 +29,7 @@ public class RelativeToWidgetPopupPositioner extends PopupPositioner {
 
     /**
      * @param widget - the widget relative to which the popup will be shown.
-     * 
+     *
      * If there is enough space to the right, the left edge of the popup will be positioned flush with
      * the left edge of the widget.<p>
      * <pre>
@@ -49,7 +49,7 @@ public class RelativeToWidgetPopupPositioner extends PopupPositioner {
      *     |popup panel|
      *     -------------
      * </pre>
-     * 
+     *
      * If there is not enough space to the left or the right and clipToWindow is on. The popup will be
      * positioned on the left edge of the screen.<p>
      * <pre>
@@ -59,7 +59,7 @@ public class RelativeToWidgetPopupPositioner extends PopupPositioner {
      *      ||popup panel|
      *      |-------------
      * </pre>
-     * 
+     *
      * If you would prefer the popupPanel to always be flush with the widget call
      * {@link #RelativeToWidgetPopupPositioner(IsWidget, boolean)}
      * and set clipToWindow to false
@@ -71,7 +71,7 @@ public class RelativeToWidgetPopupPositioner extends PopupPositioner {
     /**
      * @param widget - the widget relative to which the popup will be shown.
      * @param clipToWindow - set to false to always position the popup flush to an edge of the widget.
-     * 
+     *
      * If there is enough space to the right, the left edge of the popup will be positioned flush with
      * the left edge of the widget.<p>
      * <pre>
@@ -91,7 +91,7 @@ public class RelativeToWidgetPopupPositioner extends PopupPositioner {
      *     |popup panel|
      *     -------------
      * </pre>
-     * 
+     *
      * If there is not enough space to the left or the right and clipToWindow is on. The popup will be
      * positioned on the left edge of the screen.<p>
      * <pre>
@@ -101,7 +101,7 @@ public class RelativeToWidgetPopupPositioner extends PopupPositioner {
      *      ||popup panel|
      *      |-------------
      * </pre>
-     * 
+     *
      * Set clipToWindow to false to always position the popup flush to an edge of the widget and expand
      * the screen when it will not fit.
      */

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/view/TopLeftPopupPositioner.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/view/TopLeftPopupPositioner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/AbstractGenerator.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/AbstractGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/ApplicationControllerGenerator.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/ApplicationControllerGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/BasicProxyOutputter.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/BasicProxyOutputter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/ClassCollection.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/ClassCollection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/ClassInspector.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/ClassInspector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/GinjectorGenerator.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/GinjectorGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/GinjectorInspector.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/GinjectorInspector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/NonLeafTabContentProxyOutputter.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/NonLeafTabContentProxyOutputter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/PlaceTokenRegistryGenerator.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/PlaceTokenRegistryGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/PresenterDefinitions.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/PresenterDefinitions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/PresenterInspector.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/PresenterInspector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/PresenterTitleMethod.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/PresenterTitleMethod.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/ProviderBundleGenerator.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/ProviderBundleGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/ProxyEventMethod.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/ProxyEventMethod.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/ProxyGenerator.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/ProxyGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/ProxyOutputter.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/ProxyOutputter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/ProxyOutputterBase.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/ProxyOutputterBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/ProxyOutputterFactory.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/ProxyOutputterFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/ProxyPlaceOutputter.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/ProxyPlaceOutputter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/TabContentProxyPlaceOutputter.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/TabContentProxyPlaceOutputter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/TabInfoMethod.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/TabInfoMethod.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/linker/FormFactorPropertyGenerator.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/linker/FormFactorPropertyGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/velocity/AbstractVelocityGenerator.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/velocity/AbstractVelocityGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/velocity/GenerateFormFactorGinjectors.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/velocity/GenerateFormFactorGinjectors.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/velocity/GeneratorUtil.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/velocity/GeneratorUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/velocity/RebindModule.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/velocity/RebindModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/velocity/VelocityProperties.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/velocity/VelocityProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/velocity/ginjectors/FormFactorGinjectorFactory.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/velocity/ginjectors/FormFactorGinjectorFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/velocity/ginjectors/FormFactorGinjectorGenerator.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/velocity/ginjectors/FormFactorGinjectorGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/velocity/ginjectors/FormFactorGinjectorProviderGenerator.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/velocity/ginjectors/FormFactorGinjectorProviderGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/velocity/ginjectors/GinjectorProviderGenerator.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/velocity/ginjectors/GinjectorProviderGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/velocity/proxy/VelocityPlacetokenGenerator.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/velocity/proxy/VelocityPlacetokenGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/HandlerContainerImpl2Test.java
+++ b/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/HandlerContainerImpl2Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/HandlerContainerImplTest.java
+++ b/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/HandlerContainerImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/MvpClientGwtTestSuite.java
+++ b/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/MvpClientGwtTestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/PresenterTest.java
+++ b/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/PresenterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/PresenterWidgetTest.java
+++ b/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/PresenterWidgetTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/gwt/mvp/AdminPresenterTestUtilGwt.java
+++ b/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/gwt/mvp/AdminPresenterTestUtilGwt.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/gwt/mvp/AdminViewTestUtilGwt.java
+++ b/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/gwt/mvp/AdminViewTestUtilGwt.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/gwt/mvp/ClientModuleTestUtilGwt.java
+++ b/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/gwt/mvp/ClientModuleTestUtilGwt.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/gwt/mvp/GinjectorTestUtilGwt.java
+++ b/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/gwt/mvp/GinjectorTestUtilGwt.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/gwt/mvp/InstantiationCounterTestUtilGwt.java
+++ b/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/gwt/mvp/InstantiationCounterTestUtilGwt.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/gwt/mvp/MainPresenterTestUtilGwt.java
+++ b/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/gwt/mvp/MainPresenterTestUtilGwt.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/gwt/mvp/MainViewTestUtilGwt.java
+++ b/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/gwt/mvp/MainViewTestUtilGwt.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/gwt/mvp/MvpGwtTestInSuite.java
+++ b/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/gwt/mvp/MvpGwtTestInSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/gwt/mvp/PlaceManagerTestUtilGwt.java
+++ b/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/gwt/mvp/PlaceManagerTestUtilGwt.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/gwt/mvp/PopupPresenterTestUtilGwt.java
+++ b/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/gwt/mvp/PopupPresenterTestUtilGwt.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/gwt/mvp/PopupViewTestUtilGwt.java
+++ b/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/gwt/mvp/PopupViewTestUtilGwt.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/mvp/MainPresenterTestUtil.java
+++ b/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/mvp/MainPresenterTestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/mvp/MockInjectionTest.java
+++ b/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/mvp/MockInjectionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/mvp/RealInjectionTest.java
+++ b/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/mvp/RealInjectionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/mvp/SubPresenterWidgetTestUtil.java
+++ b/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/mvp/SubPresenterWidgetTestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/proxy/AsyncEventPresenterTestUtil.java
+++ b/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/proxy/AsyncEventPresenterTestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/proxy/AsyncEventTest.java
+++ b/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/proxy/AsyncEventTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/proxy/GatekeeperTest.java
+++ b/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/proxy/GatekeeperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/proxy/GatekeeperWithParamsTest.java
+++ b/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/proxy/GatekeeperWithParamsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/proxy/PlaceManagerImpl2Test.java
+++ b/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/proxy/PlaceManagerImpl2Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/proxy/PlaceManagerImplTest.java
+++ b/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/proxy/PlaceManagerImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/proxy/PlaceManagerTestUtil.java
+++ b/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/proxy/PlaceManagerTestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/proxy/PlaceManagerWindowMethodsTestUtil.java
+++ b/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/proxy/PlaceManagerWindowMethodsTestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/shared/proxy/ParameterTokenFormatterGwtTestInSuite.java
+++ b/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/shared/proxy/ParameterTokenFormatterGwtTestInSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-shared/src/main/java/com/gwtplatform/mvp/shared/proxy/ParameterTokenFormatter.java
+++ b/gwtp-core/gwtp-mvp-shared/src/main/java/com/gwtplatform/mvp/shared/proxy/ParameterTokenFormatter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-shared/src/main/java/com/gwtplatform/mvp/shared/proxy/PlaceRequest.java
+++ b/gwtp-core/gwtp-mvp-shared/src/main/java/com/gwtplatform/mvp/shared/proxy/PlaceRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-shared/src/main/java/com/gwtplatform/mvp/shared/proxy/PlaceTokenRegistry.java
+++ b/gwtp-core/gwtp-mvp-shared/src/main/java/com/gwtplatform/mvp/shared/proxy/PlaceTokenRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-shared/src/main/java/com/gwtplatform/mvp/shared/proxy/RouteTokenFormatter.java
+++ b/gwtp-core/gwtp-mvp-shared/src/main/java/com/gwtplatform/mvp/shared/proxy/RouteTokenFormatter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-shared/src/main/java/com/gwtplatform/mvp/shared/proxy/TokenFormatException.java
+++ b/gwtp-core/gwtp-mvp-shared/src/main/java/com/gwtplatform/mvp/shared/proxy/TokenFormatException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-shared/src/main/java/com/gwtplatform/mvp/shared/proxy/TokenFormatter.java
+++ b/gwtp-core/gwtp-mvp-shared/src/main/java/com/gwtplatform/mvp/shared/proxy/TokenFormatter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-shared/src/test/java/com/gwtplatform/mvp/shared/proxy/PlaceRequestTest.java
+++ b/gwtp-core/gwtp-mvp-shared/src/test/java/com/gwtplatform/mvp/shared/proxy/PlaceRequestTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-mvp-shared/src/test/java/com/gwtplatform/mvp/shared/proxy/RouteTokenFormatterTest.java
+++ b/gwtp-core/gwtp-mvp-shared/src/test/java/com/gwtplatform/mvp/shared/proxy/RouteTokenFormatterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-processors/src/main/java/com/gwtplatform/dispatch/annotation/GenDispatch.java
+++ b/gwtp-core/gwtp-processors/src/main/java/com/gwtplatform/dispatch/annotation/GenDispatch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-processors/src/main/java/com/gwtplatform/dispatch/annotation/GenDto.java
+++ b/gwtp-core/gwtp-processors/src/main/java/com/gwtplatform/dispatch/annotation/GenDto.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-processors/src/main/java/com/gwtplatform/dispatch/annotation/GenEvent.java
+++ b/gwtp-core/gwtp-processors/src/main/java/com/gwtplatform/dispatch/annotation/GenEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-processors/src/main/java/com/gwtplatform/dispatch/annotation/GenProxy.java
+++ b/gwtp-core/gwtp-processors/src/main/java/com/gwtplatform/dispatch/annotation/GenProxy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-processors/src/main/java/com/gwtplatform/dispatch/annotation/In.java
+++ b/gwtp-core/gwtp-processors/src/main/java/com/gwtplatform/dispatch/annotation/In.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-processors/src/main/java/com/gwtplatform/dispatch/annotation/Optional.java
+++ b/gwtp-core/gwtp-processors/src/main/java/com/gwtplatform/dispatch/annotation/Optional.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-processors/src/main/java/com/gwtplatform/dispatch/annotation/Order.java
+++ b/gwtp-core/gwtp-processors/src/main/java/com/gwtplatform/dispatch/annotation/Order.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-processors/src/main/java/com/gwtplatform/dispatch/annotation/Out.java
+++ b/gwtp-core/gwtp-processors/src/main/java/com/gwtplatform/dispatch/annotation/Out.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-processors/src/main/java/com/gwtplatform/dispatch/annotation/UseProxy.java
+++ b/gwtp-core/gwtp-processors/src/main/java/com/gwtplatform/dispatch/annotation/UseProxy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-processors/src/main/java/com/gwtplatform/dispatch/annotation/UseProxyName.java
+++ b/gwtp-core/gwtp-processors/src/main/java/com/gwtplatform/dispatch/annotation/UseProxyName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-processors/src/main/java/com/gwtplatform/dispatch/annotation/helper/BuilderGenerationHelper.java
+++ b/gwtp-core/gwtp-processors/src/main/java/com/gwtplatform/dispatch/annotation/helper/BuilderGenerationHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-processors/src/main/java/com/gwtplatform/dispatch/annotation/helper/ClassGenerationHelper.java
+++ b/gwtp-core/gwtp-processors/src/main/java/com/gwtplatform/dispatch/annotation/helper/ClassGenerationHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-processors/src/main/java/com/gwtplatform/dispatch/annotation/helper/GenerationHelper.java
+++ b/gwtp-core/gwtp-processors/src/main/java/com/gwtplatform/dispatch/annotation/helper/GenerationHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-processors/src/main/java/com/gwtplatform/dispatch/annotation/helper/InterfaceGenerationHelper.java
+++ b/gwtp-core/gwtp-processors/src/main/java/com/gwtplatform/dispatch/annotation/helper/InterfaceGenerationHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-processors/src/main/java/com/gwtplatform/dispatch/annotation/helper/ReflectionHelper.java
+++ b/gwtp-core/gwtp-processors/src/main/java/com/gwtplatform/dispatch/annotation/helper/ReflectionHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-processors/src/main/java/com/gwtplatform/dispatch/annotation/processor/GenDispatchProcessor.java
+++ b/gwtp-core/gwtp-processors/src/main/java/com/gwtplatform/dispatch/annotation/processor/GenDispatchProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-processors/src/main/java/com/gwtplatform/dispatch/annotation/processor/GenDtoProcessor.java
+++ b/gwtp-core/gwtp-processors/src/main/java/com/gwtplatform/dispatch/annotation/processor/GenDtoProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-processors/src/main/java/com/gwtplatform/dispatch/annotation/processor/GenEventProcessor.java
+++ b/gwtp-core/gwtp-processors/src/main/java/com/gwtplatform/dispatch/annotation/processor/GenEventProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-processors/src/main/java/com/gwtplatform/dispatch/annotation/processor/GenProcessor.java
+++ b/gwtp-core/gwtp-processors/src/main/java/com/gwtplatform/dispatch/annotation/processor/GenProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-processors/src/main/java/com/gwtplatform/dispatch/annotation/processor/GenProxyProcessor.java
+++ b/gwtp-core/gwtp-processors/src/main/java/com/gwtplatform/dispatch/annotation/processor/GenProxyProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-processors/src/test/java/com/gwtplatform/dispatch/annotation/Address.java
+++ b/gwtp-core/gwtp-processors/src/test/java/com/gwtplatform/dispatch/annotation/Address.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-processors/src/test/java/com/gwtplatform/dispatch/annotation/Detail.java
+++ b/gwtp-core/gwtp-processors/src/test/java/com/gwtplatform/dispatch/annotation/Detail.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-processors/src/test/java/com/gwtplatform/dispatch/annotation/DetailProxy.java
+++ b/gwtp-core/gwtp-processors/src/test/java/com/gwtplatform/dispatch/annotation/DetailProxy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-processors/src/test/java/com/gwtplatform/dispatch/annotation/DispatchAnnotationProcessingTest.java
+++ b/gwtp-core/gwtp-processors/src/test/java/com/gwtplatform/dispatch/annotation/DispatchAnnotationProcessingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-processors/src/test/java/com/gwtplatform/dispatch/annotation/DtoAnnotationProcessingTest.java
+++ b/gwtp-core/gwtp-processors/src/test/java/com/gwtplatform/dispatch/annotation/DtoAnnotationProcessingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-processors/src/test/java/com/gwtplatform/dispatch/annotation/Employee.java
+++ b/gwtp-core/gwtp-processors/src/test/java/com/gwtplatform/dispatch/annotation/Employee.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-processors/src/test/java/com/gwtplatform/dispatch/annotation/EmployeeLocator.java
+++ b/gwtp-core/gwtp-processors/src/test/java/com/gwtplatform/dispatch/annotation/EmployeeLocator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-processors/src/test/java/com/gwtplatform/dispatch/annotation/EventAnnotationProcessingTest.java
+++ b/gwtp-core/gwtp-processors/src/test/java/com/gwtplatform/dispatch/annotation/EventAnnotationProcessingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-processors/src/test/java/com/gwtplatform/dispatch/annotation/Foo.java
+++ b/gwtp-core/gwtp-processors/src/test/java/com/gwtplatform/dispatch/annotation/Foo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-processors/src/test/java/com/gwtplatform/dispatch/annotation/FooChanged.java
+++ b/gwtp-core/gwtp-processors/src/test/java/com/gwtplatform/dispatch/annotation/FooChanged.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-processors/src/test/java/com/gwtplatform/dispatch/annotation/HasThing.java
+++ b/gwtp-core/gwtp-processors/src/test/java/com/gwtplatform/dispatch/annotation/HasThing.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-processors/src/test/java/com/gwtplatform/dispatch/annotation/Person.java
+++ b/gwtp-core/gwtp-processors/src/test/java/com/gwtplatform/dispatch/annotation/Person.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-processors/src/test/java/com/gwtplatform/dispatch/annotation/PersonName.java
+++ b/gwtp-core/gwtp-processors/src/test/java/com/gwtplatform/dispatch/annotation/PersonName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-processors/src/test/java/com/gwtplatform/dispatch/annotation/ProxyAnnotationProcessingTest.java
+++ b/gwtp-core/gwtp-processors/src/test/java/com/gwtplatform/dispatch/annotation/ProxyAnnotationProcessingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-processors/src/test/java/com/gwtplatform/dispatch/annotation/RetrieveBar.java
+++ b/gwtp-core/gwtp-processors/src/test/java/com/gwtplatform/dispatch/annotation/RetrieveBar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-processors/src/test/java/com/gwtplatform/dispatch/annotation/RetrieveFoo.java
+++ b/gwtp-core/gwtp-processors/src/test/java/com/gwtplatform/dispatch/annotation/RetrieveFoo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-tester/src/main/java/com/gwtplatform/tester/AsyncMockProvider.java
+++ b/gwtp-core/gwtp-tester/src/main/java/com/gwtplatform/tester/AsyncMockProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-tester/src/main/java/com/gwtplatform/tester/DeferredCommandManager.java
+++ b/gwtp-core/gwtp-tester/src/main/java/com/gwtplatform/tester/DeferredCommandManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-tester/src/main/java/com/gwtplatform/tester/MockClientActionHandlerMap.java
+++ b/gwtp-core/gwtp-tester/src/main/java/com/gwtplatform/tester/MockClientActionHandlerMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-tester/src/main/java/com/gwtplatform/tester/MockFactory.java
+++ b/gwtp-core/gwtp-tester/src/main/java/com/gwtplatform/tester/MockFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-tester/src/main/java/com/gwtplatform/tester/MockHandlerModule.java
+++ b/gwtp-core/gwtp-tester/src/main/java/com/gwtplatform/tester/MockHandlerModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-tester/src/main/java/com/gwtplatform/tester/MockProvider.java
+++ b/gwtp-core/gwtp-tester/src/main/java/com/gwtplatform/tester/MockProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-tester/src/main/java/com/gwtplatform/tester/MockingBinder.java
+++ b/gwtp-core/gwtp-tester/src/main/java/com/gwtplatform/tester/MockingBinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-tester/src/main/java/com/gwtplatform/tester/TestDispatchAsync.java
+++ b/gwtp-core/gwtp-tester/src/main/java/com/gwtplatform/tester/TestDispatchAsync.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-tester/src/main/java/com/gwtplatform/tester/TestDispatchModule.java
+++ b/gwtp-core/gwtp-tester/src/main/java/com/gwtplatform/tester/TestDispatchModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-tester/src/main/java/com/gwtplatform/tester/TestDispatchService.java
+++ b/gwtp-core/gwtp-tester/src/main/java/com/gwtplatform/tester/TestDispatchService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-tester/src/test/java/com/gwtplatform/tester/MockingBinderTest.java
+++ b/gwtp-core/gwtp-tester/src/test/java/com/gwtplatform/tester/MockingBinderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-tester/src/test/java/com/gwtplatform/tester/MockitoMockFactory.java
+++ b/gwtp-core/gwtp-tester/src/test/java/com/gwtplatform/tester/MockitoMockFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-core/gwtp-tester/src/test/java/com/gwtplatform/tester/TestView.java
+++ b/gwtp-core/gwtp-tester/src/test/java/com/gwtplatform/tester/TestView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-crawler-service/src/main/java/com/gwtplatform/crawlerservice/server/CachedPageTimeoutSec.java
+++ b/gwtp-crawler-service/src/main/java/com/gwtplatform/crawlerservice/server/CachedPageTimeoutSec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-crawler-service/src/main/java/com/gwtplatform/crawlerservice/server/CrawlServiceServlet.java
+++ b/gwtp-crawler-service/src/main/java/com/gwtplatform/crawlerservice/server/CrawlServiceServlet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-crawler-service/src/main/java/com/gwtplatform/crawlerservice/server/HtmlUnitTimeoutMillis.java
+++ b/gwtp-crawler-service/src/main/java/com/gwtplatform/crawlerservice/server/HtmlUnitTimeoutMillis.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-crawler-service/src/main/java/com/gwtplatform/crawlerservice/server/InvalidKeyException.java
+++ b/gwtp-crawler-service/src/main/java/com/gwtplatform/crawlerservice/server/InvalidKeyException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-crawler-service/src/main/java/com/gwtplatform/crawlerservice/server/ServiceKey.java
+++ b/gwtp-crawler-service/src/main/java/com/gwtplatform/crawlerservice/server/ServiceKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-crawler-service/src/main/java/com/gwtplatform/crawlerservice/server/domain/CachedPage.java
+++ b/gwtp-crawler-service/src/main/java/com/gwtplatform/crawlerservice/server/domain/CachedPage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-crawler-service/src/main/java/com/gwtplatform/crawlerservice/server/guice/CrawlServiceModule.java
+++ b/gwtp-crawler-service/src/main/java/com/gwtplatform/crawlerservice/server/guice/CrawlServiceModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-crawler-service/src/main/java/com/gwtplatform/crawlerservice/server/objectify/OfyService.java
+++ b/gwtp-crawler-service/src/main/java/com/gwtplatform/crawlerservice/server/objectify/OfyService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-crawler-service/src/main/java/com/gwtplatform/crawlerservice/server/service/CachedPageDao.java
+++ b/gwtp-crawler-service/src/main/java/com/gwtplatform/crawlerservice/server/service/CachedPageDao.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-crawler-service/src/main/java/com/gwtplatform/crawlerservice/server/service/ObjectifyDao.java
+++ b/gwtp-crawler-service/src/main/java/com/gwtplatform/crawlerservice/server/service/ObjectifyDao.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwttest/com/gwtplatform/mvp/client/PresenterProxyIntegrationTest.java
+++ b/gwttest/com/gwtplatform/mvp/client/PresenterProxyIntegrationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not


### PR DESCRIPTION
For some reason IntelliJ keeps adding `<p/>` in copyright headers because it thinks those are javadoc. It gets very annoying over time so I ran a regex against all files.