### PR TITLE
Reuse the action returned by an interceptor in case it is a new one

### DIFF
--- a/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/DelegatingAsyncCallback.java
+++ b/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/DelegatingAsyncCallback.java
@@ -20,7 +20,6 @@ import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.gwtplatform.dispatch.client.interceptor.ExecuteCommand;
 import com.gwtplatform.dispatch.client.interceptor.Interceptor;
 import com.gwtplatform.dispatch.client.interceptor.InterceptorMismatchException;
-import com.gwtplatform.dispatch.shared.DispatchRequest;
 import com.gwtplatform.dispatch.shared.TypedAction;
 
 /**
@@ -38,7 +37,7 @@ public abstract class DelegatingAsyncCallback<A extends TypedAction<R>, R, T ext
     private final AsyncCallback<R> callback;
     private final DelegatingDispatchRequest dispatchRequest;
 
-    public DelegatingAsyncCallback(
+    protected DelegatingAsyncCallback(
             DispatchCall<A, R> dispatchCall,
             A action,
             AsyncCallback<R> callback,
@@ -65,15 +64,6 @@ public abstract class DelegatingAsyncCallback<A extends TypedAction<R>, R, T ext
         dispatchCall.onExecuteFailure(caught);
     }
 
-    @Override
-    public DispatchRequest execute(A action, AsyncCallback<R> resultCallback) {
-        if (dispatchRequest.isPending()) {
-            return dispatchCall.processCall(resultCallback);
-        } else {
-            return null;
-        }
-    }
-
     protected void delegateFailure(Interceptor interceptor) {
         InterceptorMismatchException exception =
                 new InterceptorMismatchException(action.getClass(), interceptor.getActionType());
@@ -90,7 +80,7 @@ public abstract class DelegatingAsyncCallback<A extends TypedAction<R>, R, T ext
         return dispatchRequest;
     }
 
-    protected TypedAction getAction() {
+    protected TypedAction<R> getAction() {
         return action;
     }
 }

--- a/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/DispatchCall.java
+++ b/gwtp-core/gwtp-dispatch-common-client/src/main/java/com/gwtplatform/dispatch/client/DispatchCall.java
@@ -39,10 +39,11 @@ public abstract class DispatchCall<A extends TypedAction<R>, R> {
     private final A action;
     private final ExceptionHandler exceptionHandler;
     private final SecurityCookieAccessor securityCookieAccessor;
+    private final AsyncCallback<R> callback;
 
-    private AsyncCallback<R> callback;
+    private boolean intercepted;
 
-    public DispatchCall(
+    protected DispatchCall(
             ExceptionHandler exceptionHandler,
             SecurityCookieAccessor securityCookieAccessor,
             A action,
@@ -51,6 +52,18 @@ public abstract class DispatchCall<A extends TypedAction<R>, R> {
         this.callback = callback;
         this.exceptionHandler = exceptionHandler;
         this.securityCookieAccessor = securityCookieAccessor;
+    }
+
+    public void setIntercepted(boolean intercepted) {
+        if (this.intercepted && !intercepted) {
+            throw new IllegalStateException("Can not overwrite the intercepted state of a DispatchCall.");
+        }
+
+        this.intercepted = intercepted;
+    }
+
+    public boolean isIntercepted() {
+        return intercepted;
     }
 
     /**
@@ -67,18 +80,6 @@ public abstract class DispatchCall<A extends TypedAction<R>, R> {
      * @return a {@link DispatchRequest} object.
      */
     protected abstract DispatchRequest processCall();
-
-    /**
-     * Execute the call overriding the existing callback. Used by {@link DelegatingAsyncCallback}.
-     *
-     * @param callback overriding callback.
-     *
-     * @return a {@link DispatchRequest} object.
-     */
-    protected DispatchRequest processCall(AsyncCallback<R> callback) {
-        this.callback = callback;
-        return processCall();
-    }
 
     /**
      * Returns the {@link TypedAction} wrapped by this {@link DispatchCall}.

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/DefaultDispatchCallFactory.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/DefaultDispatchCallFactory.java
@@ -27,7 +27,7 @@ import com.gwtplatform.dispatch.rest.shared.RestAction;
 import com.gwtplatform.dispatch.shared.SecurityCookieAccessor;
 
 /**
- * The default implementation for {@link com.gwtplatform.dispatch.rest.client.core.DispatchCallFactory}.
+ * The default implementation for {@link DispatchCallFactory}.
  */
 public class DefaultDispatchCallFactory implements DispatchCallFactory {
     private final ExceptionHandler exceptionHandler;
@@ -58,7 +58,7 @@ public class DefaultDispatchCallFactory implements DispatchCallFactory {
 
     @Override
     public <A extends RestAction<R>, R> RestDispatchCall<A, R> create(A action, AsyncCallback<R> callback) {
-        return new RestDispatchCall<A, R>(exceptionHandler, interceptorRegistry, securityCookieAccessor,
+        return new RestDispatchCall<A, R>(this, exceptionHandler, interceptorRegistry, securityCookieAccessor,
                 requestBuilderFactory, cookieManager, responseDeserializer, dispatchHooks, action, callback);
     }
 }

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/interceptor/AbstractRestInterceptor.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/interceptor/AbstractRestInterceptor.java
@@ -16,26 +16,39 @@
 
 package com.gwtplatform.dispatch.rest.client.interceptor;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 import com.gwtplatform.dispatch.client.interceptor.AbstractInterceptor;
 import com.gwtplatform.dispatch.rest.shared.RestAction;
 import com.gwtplatform.dispatch.shared.TypedAction;
 
 /**
- * Simple abstract super-class for {@link RestInterceptor}
- * implementations that forces the action class to be passed in as a constructor to the handler.
+ * Simple abstract super-class for {@link RestInterceptor} implementations that forces the action class to be passed in
+ * as a constructor to the handler.
  */
 public abstract class AbstractRestInterceptor extends AbstractInterceptor<RestAction, Object>
         implements RestInterceptor {
-    private final InterceptorContext[] interceptorContexts;
+    private final List<InterceptorContext> interceptorContexts;
 
-    protected AbstractRestInterceptor(InterceptorContext... interceptorContexts) {
-        super(RestAction.class); // catch all
+    protected AbstractRestInterceptor(
+            InterceptorContext context,
+            InterceptorContext... moreContexts) {
+        super(RestAction.class);
 
-        this.interceptorContexts = interceptorContexts;
+        List<InterceptorContext> contexts = new ArrayList<InterceptorContext>();
+        contexts.add(context);
+
+        if (moreContexts != null) {
+            Collections.addAll(contexts, moreContexts);
+        }
+
+        interceptorContexts = Collections.unmodifiableList(contexts);
     }
 
     @Override
-    public InterceptorContext[] getInterceptorContexts() {
+    public List<InterceptorContext> getInterceptorContexts() {
         return interceptorContexts;
     }
 

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/interceptor/RestInterceptor.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/interceptor/RestInterceptor.java
@@ -16,6 +16,8 @@
 
 package com.gwtplatform.dispatch.rest.client.interceptor;
 
+import java.util.List;
+
 import com.gwtplatform.dispatch.client.interceptor.Interceptor;
 import com.gwtplatform.dispatch.rest.shared.RestAction;
 
@@ -59,5 +61,5 @@ public interface RestInterceptor extends Interceptor<RestAction, Object> {
     /**
      * Get rest interceptor contexts.
      */
-    InterceptorContext[] getInterceptorContexts();
+    List<InterceptorContext> getInterceptorContexts();
 }

--- a/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/RestDispatchCallTest.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/RestDispatchCallTest.java
@@ -98,7 +98,7 @@ public class RestDispatchCallTest {
     }
 
     private <A extends RestAction<R>, R> RestDispatchCall<A, R> createCall(A action, AsyncCallback<R> callback) {
-        return new RestDispatchCall<A, R>(exceptionHandler, interceptorRegistry, securityCookieAccessor,
+        return new RestDispatchCall<A, R>(null, exceptionHandler, interceptorRegistry, securityCookieAccessor,
                 requestBuilderFactory, cookieManager, responseDeserializer, dispatchHooks, action, callback);
     }
 }

--- a/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/rpc/client/DefaultRpcDispatchCallFactory.java
+++ b/gwtp-core/gwtp-dispatch-rpc-client/src/main/java/com/gwtplatform/dispatch/rpc/client/DefaultRpcDispatchCallFactory.java
@@ -57,7 +57,7 @@ public class DefaultRpcDispatchCallFactory implements RpcDispatchCallFactory {
     @Override
     public <A extends Action<R>, R extends Result> RpcDispatchExecuteCall<A, R> create(A action,
             AsyncCallback<R> callback) {
-        return new RpcDispatchExecuteCall<A, R>(dispatchService, exceptionHandler, clientActionHandlerRegistry,
+        return new RpcDispatchExecuteCall<A, R>(this, dispatchService, exceptionHandler, clientActionHandlerRegistry,
                 interceptorRegistry, securityCookieAccessor, dispatchHooks, action, callback);
     }
 
@@ -65,6 +65,6 @@ public class DefaultRpcDispatchCallFactory implements RpcDispatchCallFactory {
     public <A extends Action<R>, R extends Result> RpcDispatchUndoCall<A, R> create(A action,
             R result, AsyncCallback<Void> callback) {
         return new RpcDispatchUndoCall<A, R>(dispatchService, exceptionHandler, clientActionHandlerRegistry,
-                interceptorRegistry, securityCookieAccessor, dispatchHooks, action, result, callback);
+                securityCookieAccessor, dispatchHooks, action, result, callback);
     }
 }


### PR DESCRIPTION
This is done in order to preserve immutability of objects and give interceptors a chance to update the actions.

I need to merge this asap (blocker for our clients)