### PR TITLE
Make sure tests always run in the correct order

### DIFF
--- a/gwtp-core/gwtp-mvp-client/pom.xml
+++ b/gwtp-core/gwtp-mvp-client/pom.xml
@@ -33,6 +33,13 @@
                     </preloadSources>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <runOrder>alphabetical</runOrder>
+                </configuration>
+            </plugin>
         </plugins>
         <resources>
             <!-- Bundle sources with the jar, so they are visible to GWT's compiler -->


### PR DESCRIPTION
This pull request addresses issue #725. With the added surefire plugin configuration, we make sure tests are always run in the same order which in this case (alphabetical) also happens to be the 'correct' order.