### PR TITLE
Made PlaceManagerImplTest independent of other tests

### DIFF
--- a/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/proxy/PlaceManagerImplTest.java
+++ b/gwtp-core/gwtp-mvp-client/src/test/java/com/gwtplatform/mvp/client/proxy/PlaceManagerImplTest.java
@@ -29,6 +29,7 @@ import org.jukito.TestSingleton;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import com.google.gwt.junit.GWTMockUtilities;
 import com.google.gwt.user.client.Command;
 import com.google.web.bindery.event.shared.EventBus;
 import com.google.web.bindery.event.shared.SimpleEventBus;
@@ -57,6 +58,7 @@ public class PlaceManagerImplTest {
     public static class Module extends JukitoModule {
         @Override
         protected void configureTest() {
+            GWTMockUtilities.disarm();
             bind(DeferredCommandManager.class).in(TestSingleton.class);
             bind(EventBus.class).to(SimpleEventBus.class).in(TestSingleton.class);
             bind(PlaceManager.class).to(PlaceManagerTestUtil.class).in(TestSingleton.class);


### PR DESCRIPTION
To make `PlaceManagerImplTest` independent of `PlaceManagerImpl2Test`, we just need to add `GWTMockUtilities.disarm()`. This voids the need to have tests run in a specific order.

Whenever `GWTMockUtilities.disarm()` is called however, we should also call `GWTMockUtilities.restore()` somewhere when the test ends if we really want to do it by the book. There are other tests in which `disarm` is called without a corresponding `restore` (hence the previously indeterministic test behavior) but fixing this is behind the scope of this issue I think.