### PR TITLE
Stop swallowing compile errors ApplicationControllerGenerator!

### DIFF
--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/fallback/ApplicationControllerFallback.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/fallback/ApplicationControllerFallback.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2015 ArcBees Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.gwtplatform.mvp.client.fallback;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.core.client.Scheduler;
+import com.google.gwt.user.client.ui.HTML;
+import com.google.gwt.user.client.ui.RootPanel;
+import com.gwtplatform.mvp.client.ApplicationController;
+
+public class ApplicationControllerFallback implements ApplicationController {
+
+    public static final String REASON = "There must have been an issue generating " +
+            "the ApplicationController. Please check your module configuration, ensure there " +
+            "are no compile errors in your source code and ensure you are not importing sources " +
+            "that cannot be compiled by GWT.";
+
+    @Override
+    public void init() {
+        GWT.log(REASON);
+
+        Scheduler.get().scheduleDeferred(new Scheduler.ScheduledCommand() {
+            @Override
+            public void execute() {
+                RootPanel.get().add(new HTML("<h3>" + REASON + "</h3>"));
+            }
+        });
+    }
+
+    @Override
+    public void onModuleLoad() {
+        init();
+    }
+}

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/fallback/BootstrapperFallback.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/fallback/BootstrapperFallback.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2015 ArcBees Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.gwtplatform.mvp.client.fallback;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.core.client.Scheduler;
+import com.google.gwt.user.client.ui.HTML;
+import com.google.gwt.user.client.ui.RootPanel;
+import com.gwtplatform.mvp.client.Bootstrapper;
+
+public class BootstrapperFallback implements Bootstrapper {
+
+    private static final String REASON = "There must have been an issue generating the Bootstrapper. " +
+            "Please check your module configuration, ensure there are no compile errors in your source code " +
+            "and ensure you are not importing sources that cannot be compiled by GWT.";
+
+    @Override
+    public void onBootstrap() {
+        GWT.log(REASON);
+
+        Scheduler.get().scheduleDeferred(new Scheduler.ScheduledCommand() {
+            @Override
+            public void execute() {
+                RootPanel.get().add(new HTML("<h3>" + REASON + "</h3>"));
+            }
+        });
+    }
+}

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/fallback/PreBootstrapperFallback.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/fallback/PreBootstrapperFallback.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2015 ArcBees Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.gwtplatform.mvp.client.fallback;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.core.client.Scheduler;
+import com.google.gwt.user.client.ui.HTML;
+import com.google.gwt.user.client.ui.RootPanel;
+import com.gwtplatform.mvp.client.PreBootstrapper;
+
+public class PreBootstrapperFallback implements PreBootstrapper {
+
+    private static final String REASON = "There must have been an issue generating the PreBootstrapper. " +
+            "Please check your module configuration, ensure there are no compile errors in your source code " +
+            "and ensure you are not importing sources that cannot be compiled by GWT.";
+
+    @Override
+    public void onPreBootstrap() {
+        GWT.log(REASON);
+
+        Scheduler.get().scheduleDeferred(new Scheduler.ScheduledCommand() {
+            @Override
+            public void execute() {
+                RootPanel.get().add(new HTML("<h3>" + REASON + "</h3>"));
+            }
+        });
+    }
+}

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/ApplicationControllerGenerator.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/ApplicationControllerGenerator.java
@@ -135,7 +135,13 @@ public class ApplicationControllerGenerator extends AbstractGenerator {
             getTreeLogger().log(TreeLogger.ERROR, PROPERTY_BOOTSTRAPPER_EMPTY);
         }
 
-        return findAndVerifyType(typeName, Bootstrapper.class, BootstrapperFallback.class);
+        JClassType type;
+        try {
+            type = findAndVerifyType(typeName, Bootstrapper.class);
+        } catch (UnableToCompleteException ex) {
+            type = findAndVerifyType(typeName, BootstrapperFallback.class);
+        }
+        return type;
     }
 
     /**
@@ -147,8 +153,13 @@ public class ApplicationControllerGenerator extends AbstractGenerator {
             return null;
         }
 
-        return findAndVerifyType(typeName, PreBootstrapper.class,
-                PreBootstrapperFallback.class);
+        JClassType type;
+        try {
+            type = findAndVerifyType(typeName, PreBootstrapper.class);
+        } catch (UnableToCompleteException ex) {
+            type = findAndVerifyType(typeName, PreBootstrapperFallback.class);
+        }
+        return type;
     }
 
     /**
@@ -176,23 +187,12 @@ public class ApplicationControllerGenerator extends AbstractGenerator {
     /**
      * Find the Java type by the given class name and verify that it extends the given interface.
      */
-    private JClassType findAndVerifyType(String typeName, Class<?> interfaceClass) throws UnableToCompleteException {
-        return findAndVerifyType(typeName, interfaceClass, null);
-    }
-
-    /**
-     * Find the Java type by the given class name and verify that it extends the given interface.
-     */
-    private JClassType findAndVerifyType(String typeName, Class<?> interfaceClass, Class<?> fallbackClass)
+    private JClassType findAndVerifyType(String typeName, Class<?> interfaceClass)
             throws UnableToCompleteException {
         JClassType type = getTypeOracle().findType(typeName);
         if (type == null) {
-            if (fallbackClass == null) {
-                getTreeLogger().log(TreeLogger.ERROR, String.format(TYPE_NOT_FOUND, typeName));
-                throw new UnableToCompleteException();
-            } else {
-                type = getTypeOracle().findType(fallbackClass.getName());
-            }
+            getTreeLogger().log(TreeLogger.ERROR, String.format(TYPE_NOT_FOUND, typeName));
+            throw new UnableToCompleteException();
         }
 
         JClassType interfaceType = getType(interfaceClass.getName());

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/ApplicationControllerGenerator.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/rebind/ApplicationControllerGenerator.java
@@ -31,6 +31,9 @@ import com.google.gwt.user.rebind.SourceWriter;
 import com.gwtplatform.mvp.client.Bootstrapper;
 import com.gwtplatform.mvp.client.DelayedBindRegistry;
 import com.gwtplatform.mvp.client.PreBootstrapper;
+import com.gwtplatform.mvp.client.fallback.ApplicationControllerFallback;
+import com.gwtplatform.mvp.client.fallback.BootstrapperFallback;
+import com.gwtplatform.mvp.client.fallback.PreBootstrapperFallback;
 
 /**
  * Will generate a {@link com.gwtplatform.mvp.client.ApplicationController}. If the user wants his Generator to be
@@ -38,10 +41,13 @@ import com.gwtplatform.mvp.client.PreBootstrapper;
  * revealCurrentPlace() from the place manager.
  */
 public class ApplicationControllerGenerator extends AbstractGenerator {
+    private static final String PROBLEM_GENERATING = "There was a problem generating the ApplicationController," +
+            " this can be caused by bad GWT module configuration or compile errors in your source code.";
     private static final String PROPERTY_BOOTSTRAPPER_EMPTY =
             "Required configuration property 'gwtp.bootstrapper' can not be empty!.";
     private static final String PROPERTY_NOT_FOUND = "Undefined configuration property '%s'.";
-    private static final String TYPE_NOT_FOUND = "The type '%s' was not found.";
+    private static final String TYPE_NOT_FOUND = "The type '%s' was not found, either the class name is " +
+            "wrong or there are compile errors in your code.";
     private static final String HINT_URL = "https://github.com/ArcBees/GWTP/wiki/Bootstrapping";
     private static final String DOES_NOT_EXTEND_INTERFACE = "'%s' doesn't implement the '%s' interface. See "
             + HINT_URL;
@@ -73,7 +79,6 @@ public class ApplicationControllerGenerator extends AbstractGenerator {
             return typeName + SUFFIX;
         }
         try {
-
             JClassType preBootstrapper = getPreBootstrapper();
 
             ClassSourceFileComposerFactory composer = initComposer(preBootstrapper);
@@ -89,6 +94,15 @@ public class ApplicationControllerGenerator extends AbstractGenerator {
             closeDefinition(sw);
 
             return getPackageName() + "." + getClassName();
+        } catch (UnableToCompleteException e) {
+            // Java compile errors can cause problems during compilation
+            // for tasks like TypeOracle#findType will return null if there
+            // are compile errors, we should at least hint this possibility.
+            getTreeLogger().log(TreeLogger.ERROR, PROBLEM_GENERATING);
+
+            // Return ApplicationControllerFallback class to avoid
+            // swallowing the actual compiler issues if there are any.
+            return ApplicationControllerFallback.class.getName();
         } finally {
             printWriter.close();
         }
@@ -117,12 +131,11 @@ public class ApplicationControllerGenerator extends AbstractGenerator {
     private JClassType getBootstrapper() throws UnableToCompleteException {
         String typeName = lookupTypeNameByProperty(PROPERTY_NAME_BOOTSTRAPPER);
         if (typeName == null) {
-            getTreeLogger()
-                    .log(TreeLogger.ERROR, PROPERTY_BOOTSTRAPPER_EMPTY);
-            throw new UnableToCompleteException();
+
+            getTreeLogger().log(TreeLogger.ERROR, PROPERTY_BOOTSTRAPPER_EMPTY);
         }
 
-        return findAndVerifyType(typeName, Bootstrapper.class);
+        return findAndVerifyType(typeName, Bootstrapper.class, BootstrapperFallback.class);
     }
 
     /**
@@ -134,7 +147,8 @@ public class ApplicationControllerGenerator extends AbstractGenerator {
             return null;
         }
 
-        return findAndVerifyType(typeName, PreBootstrapper.class);
+        return findAndVerifyType(typeName, PreBootstrapper.class,
+                PreBootstrapperFallback.class);
     }
 
     /**
@@ -163,10 +177,22 @@ public class ApplicationControllerGenerator extends AbstractGenerator {
      * Find the Java type by the given class name and verify that it extends the given interface.
      */
     private JClassType findAndVerifyType(String typeName, Class<?> interfaceClass) throws UnableToCompleteException {
+        return findAndVerifyType(typeName, interfaceClass, null);
+    }
+
+    /**
+     * Find the Java type by the given class name and verify that it extends the given interface.
+     */
+    private JClassType findAndVerifyType(String typeName, Class<?> interfaceClass, Class<?> fallbackClass)
+            throws UnableToCompleteException {
         JClassType type = getTypeOracle().findType(typeName);
         if (type == null) {
-            getTreeLogger().log(TreeLogger.ERROR, String.format(TYPE_NOT_FOUND, typeName));
-            throw new UnableToCompleteException();
+            if (fallbackClass == null) {
+                getTreeLogger().log(TreeLogger.ERROR, String.format(TYPE_NOT_FOUND, typeName));
+                throw new UnableToCompleteException();
+            } else {
+                type = getTypeOracle().findType(fallbackClass.getName());
+            }
         }
 
         JClassType interfaceType = getType(interfaceClass.getName());

--- a/pom.xml
+++ b/pom.xml
@@ -179,6 +179,10 @@
             <name>Richard Wallis</name>
             <email>rdwallis@gmail.com</email>
         </contributor>
+        <contributor>
+            <name>Ben Dol</name>
+            <email>dolb90@gmail.com</email>
+        </contributor>
     </contributors>
 
     <scm>


### PR DESCRIPTION
When a type produces GWT compile errors (i.e. Java compile errors or client code errors) the `TypeOracle#findType` returns null on types that are affected by the compile error. Most of the time this would be the entry point classes, resulting in an ambiguous error message when producing the ApplicationController. For example when it attempts to load the Bootstrapper it returns the type as null when there are Java compile errors or GWT client specific compile errors originating from the entry-point class.

For example, this is the error I would expect to see: 
```
[WARN] Class com.bugs.NotInClientOrSharedPackage is used in Gin, but not available in GWT client code.
````

But instead I would get something like this:
```
[ERROR] The type 'nz.co.doltech.xxx.client.Application.PreBootstrapperImpl' was not found.
```

This issue has bugged be for quite some time now especially when an ammeter with GWT is using GWTP so its nice to finally have it resolved!

**Before:**
```java
GET /recompile/wayhome
   Job nz.co.doltech.wayhome.WayHomeDev_1_0
      starting job: nz.co.doltech.wayhome.WayHomeDev_1_0
      binding: locale=en
      Compiling module nz.co.doltech.wayhome.WayHomeDev
         Ignored 14 units with compilation errors in first pass.
Compile with -strict or with -logLevel set to TRACE or DEBUG to see all errors.
         Computing all possible rebind results for 'com.gwtplatform.mvp.client.ApplicationController'
            Rebinding com.gwtplatform.mvp.client.ApplicationController
               Invoking generator com.gwtplatform.mvp.rebind.ApplicationControllerGenerator
                  [ERROR] The type 'nz.co.doltech.wayhome.client.Application.PreApplicationImpl' was not found.
         [ERROR] Errors in 'gen/com/google/gwt/lang/nz_00046co_00046doltech_00046wayhome_00046WayHomeDev__EntryMethodHolder.java'
            [ERROR] Line 3: Failed to resolve 'com.gwtplatform.mvp.client.ApplicationController' via deferred binding
         [WARN] For the following type(s), generated source was never committed (did you forget to call commit()?)
            [WARN] com.gwtplatform.mvp.client.ApplicationControllerImpl
         Unification traversed 20238 fields and methods and 1812 types. 1777 are considered part of the current module and 1777 had all of their fields and methods traversed.
```

**After:**
```java
GET /recompile/wayhome
   Job nz.co.doltech.wayhome.WayHomeDev_1_3
      starting job: nz.co.doltech.wayhome.WayHomeDev_1_3
      binding: locale=en
      Compiling module nz.co.doltech.wayhome.WayHomeDev
         Ignored 11 units with compilation errors in first pass.
Compile with -strict or with -logLevel set to TRACE or DEBUG to see all errors.
         Computing all possible rebind results for 'com.gwtplatform.mvp.client.DesktopGinjector'
            Rebinding com.gwtplatform.mvp.client.DesktopGinjector
               Invoking generator com.google.gwt.inject.rebind.GinjectorGenerator
                  [WARN] Class sun.security.jgss.HttpCaller is used in Gin, but not available in GWT client code.
                  [ERROR] Error injecting nz.co.doltech.wayhome.client.application.activate.ActivateView$Binder: Unable to create or inherit binding: No @Inject or default constructor found for nz.co.doltech.wayhome.client.application.activate.ActivateView$Binder
  Path to required node:
```