### PR TITLE
Support regular expressions for PathParams

### DIFF
--- a/gwtp-core/gwtp-dispatch-rest-shared/src/main/java/com/gwtplatform/dispatch/rest/shared/RestAction.java
+++ b/gwtp-core/gwtp-dispatch-rest-shared/src/main/java/com/gwtplatform/dispatch/rest/shared/RestAction.java
@@ -30,24 +30,24 @@ import com.gwtplatform.dispatch.shared.TypedAction;
  * @param <R> the result type.
  */
 public interface RestAction<R> extends TypedAction<R>, HasSecured {
+
     /**
-	 * Returns the raw value of the @Path annotation. This
-	 * path may also contain regular expression values for the specific variables.
-	 * 
-	 * @see JSR-311 section 3.4
-	 * @return the raw service path for this action
-	 */
+     * Returns the raw value of the @Path annotation. This path may also contain regular expression values for the
+     * specific variables.
+     * 
+     * @see JSR-311 section 3.4
+     * @return the raw service path for this action
+     */
     String getRawServicePath();
 
-	/**
-	 * Returns the relative path for this action. It should not be prepended by
-	 * the path annotated with
-	 * {@link com.gwtplatform.dispatch.rest.client.RestApplicationPath @RestApplicationPath}.
-	 * This path does not contain regular expressions for the URI templates anymore.
-	 *
-	 * @see #getRawServicePath()
-	 * @return the relative path for this action.
-	 */
+    /**
+     * Returns the relative path for this action. It should not be prepended by the path annotated with
+     * {@link com.gwtplatform.dispatch.rest.client.RestApplicationPath @RestApplicationPath}. This path does not contain
+     * regular expressions for the URI templates anymore.
+     *
+     * @see #getRawServicePath()
+     * @return the relative path for this action.
+     */
     String getPath();
 
     /**

--- a/gwtp-core/gwtp-dispatch-rest-shared/src/main/java/com/gwtplatform/dispatch/rest/shared/RestAction.java
+++ b/gwtp-core/gwtp-dispatch-rest-shared/src/main/java/com/gwtplatform/dispatch/rest/shared/RestAction.java
@@ -24,23 +24,45 @@ import com.gwtplatform.dispatch.shared.TypedAction;
 /**
  * An action used by {@link com.gwtplatform.dispatch.rest.client.RestDispatch RestDispatch}.
  * <p/>
- * You will usually want to let GWTP generate your actions by creating services as explained <a
- * href="https://github.com/ArcBees/GWTP/wiki/Rest-Dispatch#write-services-and-actions">here</a>.
+ * You will usually want to let GWTP generate your actions by creating services as explained
+ * <a href="https://github.com/ArcBees/GWTP/wiki/Rest-Dispatch#write-services-and-actions">here</a>.
  *
  * @param <R> the result type.
  */
 public interface RestAction<R> extends TypedAction<R>, HasSecured {
     /**
-     * Returns the relative path for this action. It should not be prepended by the path annotated with {@link
-     * com.gwtplatform.dispatch.rest.client.RestApplicationPath @RestApplicationPath}.
-     *
-     * @return the relative path for this action.
-     */
+	 * Returns the raw value of the @Path annotation. This
+	 * path may also contain regular expression values for the specific variables.
+	 * 
+	 * @see JSR-311 section 3.4
+	 * @return the raw service path for this action
+	 */
+    String getRawServicePath();
+
+	/**
+	 * Returns the relative path for this action. It should not be prepended by
+	 * the path annotated with
+	 * {@link com.gwtplatform.dispatch.rest.client.RestApplicationPath @RestApplicationPath}.
+	 * This path does not contain regular expressions for the URI templates anymore.
+	 *
+	 * @see #getRawServicePath()
+	 * @return the relative path for this action.
+	 */
     String getPath();
 
     /**
+     * Returns the regular expression which should be used to validate the given parameter value. In case no regular
+     * expression is specified this method will return <code>null</code>
+     * 
+     * @param pathParameter The parameter to get the regular expression for.
+     * @return The regular expression for the given parameter or <code>null</code> in case no regular expression is
+     *         defined for this path parameter
+     */
+    String getPathParameterRegex(String pathParameter);
+
+    /**
      * @return the {@link com.gwtplatform.dispatch.rest.shared.HttpMethod} designator used to send this action over
-     * HTTP.
+     *         HTTP.
      */
     HttpMethod getHttpMethod();
 
@@ -50,8 +72,8 @@ public interface RestAction<R> extends TypedAction<R>, HasSecured {
     List<HttpParameter> getParameters(HttpParameter.Type type);
 
     /**
-     * @return The object that will be serialized and used for the body of this action. There are no {@link
-     * com.gwtplatform.dispatch.rest.shared.HttpParameter.Type#FORM @FormParam} parameters.
+     * @return The object that will be serialized and used for the body of this action. There are no
+     *         {@link com.gwtplatform.dispatch.rest.shared.HttpParameter.Type#FORM @FormParam} parameters.
      */
     Object getBodyParam();
 

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/codegen/AbstractRestAction.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/codegen/AbstractRestAction.java
@@ -45,9 +45,8 @@ public abstract class AbstractRestAction<R> implements RestAction<R> {
 
     private Object bodyParam;
 
-	/**
-     * Creates a new instance of the action without parsing the regular expressions from the 
-     * rawServicePath.
+    /**
+     * Creates a new instance of the action without parsing the regular expressions from the rawServicePath.
      * 
      * @param httpParameterFactory factory to create the HTTP parameters
      * @param defaultDateFormat for the date marshalling
@@ -56,10 +55,10 @@ public abstract class AbstractRestAction<R> implements RestAction<R> {
      * @param path the path after parsing the regex definitions
      */
     protected AbstractRestAction(
-    		HttpParameterFactory httpParameterFactory, 
-    		String defaultDateFormat,
-            HttpMethod httpMethod, 
-            String rawServicePath, 
+            HttpParameterFactory httpParameterFactory,
+            String defaultDateFormat,
+            HttpMethod httpMethod,
+            String rawServicePath,
             String path) {
         this.httpParameterFactory = httpParameterFactory;
         this.defaultDateFormat = defaultDateFormat;
@@ -134,7 +133,7 @@ public abstract class AbstractRestAction<R> implements RestAction<R> {
 
     /**
      * Method is used to add information about regular expressions specified for path parameters (for details on how to
-     * specify those regular expession see JSR-311 specification).
+     * specify those regular expression see JSR-311 specification).
      * 
      * @param parameter The parameter the regex should be associated with
      * @param regex The regular expression used for the parameter

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/codegen/AbstractRestAction.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/codegen/AbstractRestAction.java
@@ -17,7 +17,9 @@
 package com.gwtplatform.dispatch.rest.client.codegen;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import com.gwtplatform.dispatch.rest.client.core.parameters.HttpParameterFactory;
 import com.gwtplatform.dispatch.rest.shared.HttpMethod;
@@ -32,24 +34,40 @@ import com.gwtplatform.dispatch.rest.shared.RestAction;
  * @param <R> the result type
  */
 public abstract class AbstractRestAction<R> implements RestAction<R> {
+
     private final HttpParameterFactory httpParameterFactory;
     private final String defaultDateFormat;
     private final HttpMethod httpMethod;
     private final String rawServicePath;
     private final List<HttpParameter> parameters;
+    private final String path;
+    private final Map<String, String> pathParamRegexMapping;
 
     private Object bodyParam;
 
+	/**
+     * Creates a new instance of the action without parsing the regular expressions from the 
+     * rawServicePath.
+     * 
+     * @param httpParameterFactory factory to create the HTTP parameters
+     * @param defaultDateFormat for the date marshalling
+     * @param httpMethod of the action
+     * @param rawServicePath the raw path (including regex definitions for path parameters)
+     * @param path the path after parsing the regex definitions
+     */
     protected AbstractRestAction(
-            HttpParameterFactory httpParameterFactory,
-            String defaultDateFormat,
-            HttpMethod httpMethod,
-            String rawServicePath) {
+    		HttpParameterFactory httpParameterFactory, 
+    		String defaultDateFormat,
+            HttpMethod httpMethod, 
+            String rawServicePath, 
+            String path) {
         this.httpParameterFactory = httpParameterFactory;
         this.defaultDateFormat = defaultDateFormat;
         this.httpMethod = httpMethod;
         this.rawServicePath = rawServicePath;
         this.parameters = new ArrayList<HttpParameter>();
+        this.path = path;
+        this.pathParamRegexMapping = new HashMap<String, String>();
     }
 
     @Override
@@ -58,8 +76,24 @@ public abstract class AbstractRestAction<R> implements RestAction<R> {
     }
 
     @Override
-    public String getPath() {
+    public String getRawServicePath() {
         return rawServicePath;
+    }
+
+    @Override
+    public String getPath() {
+        return path;
+    }
+
+    @Override
+    public String getPathParameterRegex(String pathParameter) {
+        String regex = null;
+
+        if (pathParameter != null && pathParamRegexMapping != null) {
+            regex = pathParamRegexMapping.get(pathParameter);
+        }
+
+        return regex;
     }
 
     @Override
@@ -96,6 +130,17 @@ public abstract class AbstractRestAction<R> implements RestAction<R> {
     protected void addParam(HttpParameter.Type type, String name, Object value, String dateFormat) {
         HttpParameter parameter = httpParameterFactory.create(type, name, value, dateFormat);
         parameters.add(parameter);
+    }
+
+    /**
+     * Method is used to add information about regular expressions specified for path parameters (for details on how to
+     * specify those regular expession see JSR-311 specification).
+     * 
+     * @param parameter The parameter the regex should be associated with
+     * @param regex The regular expression used for the parameter
+     */
+    protected void addParameterExpression(String parameter, String regex) {
+        pathParamRegexMapping.put(parameter, regex);
     }
 
     protected void setBodyParam(Object value) {

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/DefaultUriFactory.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/core/DefaultUriFactory.java
@@ -19,9 +19,12 @@ package com.gwtplatform.dispatch.rest.client.core;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import javax.inject.Inject;
 
+import com.google.gwt.logging.client.LogConfiguration;
 import com.gwtplatform.dispatch.rest.client.RestApplicationPath;
 import com.gwtplatform.dispatch.rest.client.annotations.GlobalQueryParams;
 import com.gwtplatform.dispatch.rest.client.gin.RestParameterBindings;
@@ -32,6 +35,7 @@ import com.gwtplatform.dispatch.rest.shared.RestAction;
 public class DefaultUriFactory implements UriFactory {
     private final RestParameterBindings globalQueryParams;
     private final String applicationPath;
+    private final Logger logger = Logger.getLogger(this.getClass().getName());
 
     @Inject
     DefaultUriFactory(
@@ -94,8 +98,15 @@ public class DefaultUriFactory implements UriFactory {
         for (HttpParameter param : params) {
             List<Entry<String, String>> entries = param.getEncodedEntries();
             assert entries.size() == 1;
-
             Entry<String, String> entry = entries.get(0);
+            String key = entry.getKey();
+            String value = entry.getValue();
+            String regex = action.getPathParameterRegex(key);
+            if (LogConfiguration.loggingIsEnabled() && regex != null && !value.matches(regex)) {
+                logger.log(Level.WARNING, "Path parameter '" + key + "': Value '" + value
+                        + "' does not match regular expression '" + regex + "'.");
+            }
+
             path = path.replace("{" + entry.getKey() + "}", entry.getValue());
         }
 

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/interceptor/InterceptorContextRestAction.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/client/interceptor/InterceptorContextRestAction.java
@@ -34,10 +34,7 @@ class InterceptorContextRestAction implements RestAction<Object> {
     private final String path;
     private final List<HttpParameter> parameters;
 
-    InterceptorContextRestAction(
-            HttpMethod httpMethod,
-            String path,
-            int queryCount) {
+    InterceptorContextRestAction(HttpMethod httpMethod, String path, int queryCount) {
         this.httpMethod = httpMethod;
         this.path = path;
         this.parameters = new ArrayList<HttpParameter>();
@@ -101,5 +98,15 @@ class InterceptorContextRestAction implements RestAction<Object> {
     @Override
     public List<ContentType> getClientConsumedContentTypes() {
         return null;
+    }
+
+    @Override
+    public String getPathParameterRegex(String pathParameter) {
+        return null;
+    }
+
+    @Override
+    public String getRawServicePath() {
+        return getPath();
     }
 }

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/action/ActionDefinition.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/action/ActionDefinition.java
@@ -18,6 +18,7 @@ package com.gwtplatform.dispatch.rest.rebind.action;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import com.google.gwt.core.ext.typeinfo.JClassType;
@@ -29,7 +30,9 @@ import com.gwtplatform.dispatch.rest.shared.HttpMethod;
 
 public class ActionDefinition extends ClassDefinition {
     private final HttpMethod verb;
+    private final String rawServicePath;
     private final String path;
+    private final Map<String, String> pathParamRegexMapping;
     private final boolean secured;
     private final Set<ContentType> consumes;
     private final Set<ContentType> produces;
@@ -41,7 +44,9 @@ public class ActionDefinition extends ClassDefinition {
             String packageName,
             String className,
             HttpMethod verb,
+            String rawServicePath,
             String path,
+            Map<String, String> pathParamRegexMapping,
             boolean secured,
             Set<ContentType> consumes,
             Set<ContentType> produces,
@@ -51,7 +56,9 @@ public class ActionDefinition extends ClassDefinition {
         super(packageName, className);
 
         this.verb = verb;
+        this.rawServicePath = rawServicePath;
         this.path = path;
+        this.pathParamRegexMapping = pathParamRegexMapping;
         this.secured = secured;
         this.consumes = consumes;
         this.produces = produces;
@@ -66,6 +73,14 @@ public class ActionDefinition extends ClassDefinition {
 
     public String getPath() {
         return path;
+    }
+
+    public String getRawServicePath() {
+        return rawServicePath;
+    }
+
+    public Map<String, String> getPathParamRegexMapping() {
+        return pathParamRegexMapping;
     }
 
     public boolean isSecured() {

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/action/RestActionGenerator.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/action/RestActionGenerator.java
@@ -16,6 +16,9 @@
 
 package com.gwtplatform.dispatch.rest.rebind.action;
 
+import static com.gwtplatform.dispatch.rest.rebind.parameter.HttpParameterType.FORM;
+import static com.gwtplatform.dispatch.rest.rebind.parameter.HttpParameterType.isHttpParameter;
+
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -51,13 +54,11 @@ import com.gwtplatform.dispatch.rest.rebind.utils.ClassNameGenerator;
 import com.gwtplatform.dispatch.rest.rebind.utils.ContentTypeResolver;
 import com.gwtplatform.dispatch.rest.rebind.utils.Generators;
 import com.gwtplatform.dispatch.rest.rebind.utils.Logger;
+import com.gwtplatform.dispatch.rest.rebind.utils.PathInformation;
 import com.gwtplatform.dispatch.rest.rebind.utils.PathResolver;
 import com.gwtplatform.dispatch.rest.shared.ContentType;
 import com.gwtplatform.dispatch.rest.shared.HttpMethod;
 import com.gwtplatform.dispatch.rest.shared.NoXsrfHeader;
-
-import static com.gwtplatform.dispatch.rest.rebind.parameter.HttpParameterType.FORM;
-import static com.gwtplatform.dispatch.rest.rebind.parameter.HttpParameterType.isHttpParameter;
 
 public class RestActionGenerator extends AbstractVelocityGenerator implements ActionGenerator {
     private static class FilteredParameters {
@@ -140,15 +141,17 @@ public class RestActionGenerator extends AbstractVelocityGenerator implements Ac
 
         if (printWriter != null) {
             HttpMethod verb = resolveHttpVerb();
-            String path = resolvePath();
+            PathInformation pathInformation = PathResolver.resolvePathInformation(resourceDefinition.getPath(), method);
             boolean secured = resolveSecured();
             JClassType resultType = resolveResultType();
             FilteredParameters parameters = filterParameters();
             Set<ContentType> consumes = resolveConsumes(parameters.getBodyParameter());
             Set<ContentType> produces = resolveProduces(resultType);
 
-            actionDefinition = new ActionDefinition(getPackageName(), getImplName(), verb, path, secured, consumes,
-                    produces, resultType, parameters.getHttpParameters(), parameters.getBodyParameter());
+            actionDefinition = new ActionDefinition(getPackageName(), getImplName(), verb, pathInformation
+                    .getRawServicePath(), pathInformation.getPath(), pathInformation.getPathParamRegexMapping(),
+                    secured, consumes, produces, resultType, parameters.getHttpParameters(), parameters
+                            .getBodyParameter());
 
             mergeTemplate(printWriter);
             commit(printWriter);
@@ -176,6 +179,8 @@ public class RestActionGenerator extends AbstractVelocityGenerator implements Ac
         variables.put("secured", actionDefinition.isSecured());
         variables.put("httpVerb", actionDefinition.getVerb());
         variables.put("path", actionDefinition.getPath());
+        variables.put("rawServicePath", actionDefinition.getRawServicePath());
+        variables.put("pathParamRegexMapping", actionDefinition.getPathParamRegexMapping());
         variables.put("body", bodyTypeName);
         variables.put("bodyParameterName", bodyParameterName);
         variables.put("parameters", parameters);
@@ -235,10 +240,6 @@ public class RestActionGenerator extends AbstractVelocityGenerator implements Ac
         }
 
         return verb;
-    }
-
-    private String resolvePath() {
-        return PathResolver.resolve(resourceDefinition.getPath(), method);
     }
 
     private boolean resolveSecured() {

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/action/RestActionGenerator.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/action/RestActionGenerator.java
@@ -16,9 +16,6 @@
 
 package com.gwtplatform.dispatch.rest.rebind.action;
 
-import static com.gwtplatform.dispatch.rest.rebind.parameter.HttpParameterType.FORM;
-import static com.gwtplatform.dispatch.rest.rebind.parameter.HttpParameterType.isHttpParameter;
-
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -59,6 +56,9 @@ import com.gwtplatform.dispatch.rest.rebind.utils.PathResolver;
 import com.gwtplatform.dispatch.rest.shared.ContentType;
 import com.gwtplatform.dispatch.rest.shared.HttpMethod;
 import com.gwtplatform.dispatch.rest.shared.NoXsrfHeader;
+
+import static com.gwtplatform.dispatch.rest.rebind.parameter.HttpParameterType.FORM;
+import static com.gwtplatform.dispatch.rest.rebind.parameter.HttpParameterType.isHttpParameter;
 
 public class RestActionGenerator extends AbstractVelocityGenerator implements ActionGenerator {
     private static class FilteredParameters {

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/utils/PathInformation.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/utils/PathInformation.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2011 ArcBees Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package com.gwtplatform.dispatch.rest.rebind.utils;
 
 import java.util.Map;

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/utils/PathInformation.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/utils/PathInformation.java
@@ -1,0 +1,28 @@
+package com.gwtplatform.dispatch.rest.rebind.utils;
+
+import java.util.Map;
+
+public class PathInformation {
+    private final String rawServicePath;
+    private final String path;
+    private final Map<String, String> pathParamRegexMapping;
+
+    public PathInformation(String rawServicePath, String path, Map<String, String> pathParamRegexMapping) {
+        super();
+        this.rawServicePath = rawServicePath;
+        this.path = path;
+        this.pathParamRegexMapping = pathParamRegexMapping;
+    }
+
+    public String getRawServicePath() {
+        return rawServicePath;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public Map<String, String> getPathParamRegexMapping() {
+        return pathParamRegexMapping;
+    }
+}

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/utils/PathResolver.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/utils/PathResolver.java
@@ -30,11 +30,11 @@ public class PathResolver {
     /* a path with regular expression looks like: @Path("{id:[0-9]*}/subpath") */
     private static final String REGEX_MATCH_PATH_PATTERN =
             "\\{ *(\\w[\\w\\.-]*) *(\\: *(((\\\\\\{)|(\\\\\\})|(\\[[^\\]]*\\])|([^\\{\\}])|(\\{[0-9\\,]+\\}))*))?"
-            + "[^\\\\]?\\}";
+                    + "[^\\\\]?\\}";
     private static final int REGEX_PATH_PATTERN_GROUP_PARAMETER = 1;
     private static final int REGEX_PATH_PATTERN_GROUP_REGEX = 3;
     private static final int REGEX_PATH_PATTERN_GROUPS = 9;
-    
+
     public static String resolve(String basePath, HasAnnotations type) {
         String path = resolve(type);
         path = concatenate(basePath, path);
@@ -74,14 +74,14 @@ public class PathResolver {
 
         return newPath;
     }
-    
+
     public static PathInformation resolvePathInformation(String path, HasAnnotations method) {
         String rawPath = PathResolver.resolve(path, method);
         String parsedPath = null;
         Map<String, String> pathParamRegexMapping = null;
 
         if (!isNullOrEmpty(rawPath)) {
-        	parsedPath = resolvePath(rawPath);
+            parsedPath = resolvePath(rawPath);
 
             if (rawPath.equals(path)) {
                 pathParamRegexMapping = extractPathParameterRegex(rawPath);

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/utils/PathResolver.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/utils/PathResolver.java
@@ -16,11 +16,25 @@
 
 package com.gwtplatform.dispatch.rest.rebind.utils;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import javax.ws.rs.Path;
 
 import com.google.gwt.core.ext.typeinfo.HasAnnotations;
 
 public class PathResolver {
+
+    /* a path with regular expression looks like: @Path("{id:[0-9]*}/subpath") */
+    private static final String REGEX_MATCH_PATH_PATTERN =
+            "\\{ *(\\w[\\w\\.-]*) *(\\: *(((\\\\\\{)|(\\\\\\})|(\\[[^\\]]*\\])|([^\\{\\}])|(\\{[0-9\\,]+\\}))*))?"
+            + "[^\\\\]?\\}";
+    private static final int REGEX_PATH_PATTERN_GROUP_PARAMETER = 1;
+    private static final int REGEX_PATH_PATTERN_GROUP_REGEX = 3;
+    private static final int REGEX_PATH_PATTERN_GROUPS = 9;
+    
     public static String resolve(String basePath, HasAnnotations type) {
         String path = resolve(type);
         path = concatenate(basePath, path);
@@ -59,5 +73,54 @@ public class PathResolver {
         }
 
         return newPath;
+    }
+    
+    public static PathInformation resolvePathInformation(String path, HasAnnotations method) {
+        String rawPath = PathResolver.resolve(path, method);
+        String parsedPath = null;
+        Map<String, String> pathParamRegexMapping = null;
+
+        if (!isNullOrEmpty(rawPath)) {
+        	parsedPath = resolvePath(rawPath);
+
+            if (rawPath.equals(path)) {
+                pathParamRegexMapping = extractPathParameterRegex(rawPath);
+            }
+
+        }
+        return new PathInformation(rawPath, parsedPath, pathParamRegexMapping);
+    }
+
+    public static Map<String, String> extractPathParameterRegex(String rawPath) {
+        Map<String, String> regexMapping = new HashMap<String, String>();
+
+        Pattern pattern = Pattern.compile(REGEX_MATCH_PATH_PATTERN);
+        Matcher matcher = pattern.matcher(rawPath);
+
+        while (matcher.find()) {
+            if (matcher.groupCount() == REGEX_PATH_PATTERN_GROUPS) {
+                /* extract parameter and regex */
+                String parameter = matcher.group(REGEX_PATH_PATTERN_GROUP_PARAMETER);
+                String regex = matcher.group(REGEX_PATH_PATTERN_GROUP_REGEX);
+
+                /* only consider the values if both of them are set / can be retrieved */
+                if (!isNullOrEmpty(parameter) && !isNullOrEmpty(regex)) {
+                    regexMapping.put(parameter, regex);
+                }
+            }
+        }
+
+        return regexMapping;
+    }
+
+    public static String resolvePath(String rawPath) {
+        Pattern pattern = Pattern.compile(REGEX_MATCH_PATH_PATTERN);
+        Matcher matcher = pattern.matcher(rawPath);
+
+        return matcher.replaceAll("{$" + REGEX_PATH_PATTERN_GROUP_PARAMETER + "}");
+    }
+
+    private static boolean isNullOrEmpty(String value) {
+        return value == null || value.trim().isEmpty();
     }
 }

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/utils/PathResolver.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/utils/PathResolver.java
@@ -83,11 +83,16 @@ public class PathResolver {
         if (!isNullOrEmpty(rawPath)) {
             parsedPath = resolvePath(rawPath);
 
-            if (rawPath.equals(path)) {
+            if (!rawPath.equals(parsedPath)) {
+                /*
+                 * the parsed path (path without regular expression information) is different to the rawPath - so it
+                 * seems a regular expression information is been removed. in this case try to extract the regex
+                 * information
+                 */
                 pathParamRegexMapping = extractPathParameterRegex(rawPath);
             }
-
         }
+
         return new PathInformation(rawPath, parsedPath, pathParamRegexMapping);
     }
 

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/utils/PathResolverTest.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/rebind/utils/PathResolverTest.java
@@ -1,0 +1,120 @@
+package com.gwtplatform.dispatch.rest.rebind.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.junit.Test;
+
+public class PathResolverTest {
+
+    @Test
+    public void regexInformationShouldNotBePartOfPath() {
+    	// When
+        String resolvedPath = PathResolver.resolvePath("{id: [0-9]*}/subpath/{sid:[0-9]{1,9}}");
+        
+        // Then
+        assertThat(resolvedPath).isEqualTo("{id}/subpath/{sid}");
+    }
+
+    @Test
+    public void pathParameterWithoutRegexShouldNotBeChanged() {
+        // When
+    	String resolvedPath = PathResolver.resolvePath("{id: [0-9]*}/subpath/{sid}");
+
+        // Then
+    	assertThat(resolvedPath).isEqualTo("{id}/subpath/{sid}");
+    }
+
+    @Test
+    public void regexInformationCanBeRetrievedForParameter() {
+    	// When
+    	Map<String, String> regex = PathResolver.extractPathParameterRegex("{id: [0-9]*}/subpath");
+
+        // Then
+        assertThat(regex.get("id")).isEqualTo("[0-9]*");
+    }
+
+    @Test
+    public void multipleRegexInformationCanBeRetrievedForParameter() {
+        // When
+        String idRegex = "[0-9]*";
+        String sidRegex = "[0-9]{1,9}";
+        String imeiRegex = "[0-9\\:\\/]{15}";
+        StringBuilder paramBuilder = new StringBuilder();
+        paramBuilder.append("{id: ").append(idRegex).append("}");
+        paramBuilder.append("/subpath");
+        paramBuilder.append("/{sid: ").append(sidRegex).append("}");
+        paramBuilder.append("/mobile");
+        paramBuilder.append("/{imei: ").append(imeiRegex).append("}");
+        Map<String, String> regex = PathResolver.extractPathParameterRegex(paramBuilder.toString());
+
+        // Then
+        assertThat(regex.get("id")).isEqualTo(idRegex);
+        assertThat(regex.get("sid")).isEqualTo(sidRegex);
+        assertThat(regex.get("imei")).isEqualTo(imeiRegex);
+        assertThat(regex.get("subpath")).isNull();
+        assertThat(regex.get("mobile")).isNull();
+    }
+
+    @Test
+    public void regexWithEscapedAngleBracketsCanBeResolved() {
+    	// When
+        String regex = "[a-zA-Z0-9\\{](-[a-zA-Z0-9])-[a-zA-Z0-9]{12}";
+        Map<String, String> regexMap = PathResolver.extractPathParameterRegex(
+                "/{id:[a-zA-Z0-9\\{](-[a-zA-Z0-9])-[a-zA-Z0-9]{12}}");
+
+        // Then
+        assertThat(regexMap.get("id")).isEqualTo(regex);
+    }
+
+    @Test
+    public void multipleAndMoreComplexRegexInformationCanBeRetrievedForParameter() {
+        // When
+        String nameRegex = "[0-9]*";
+        String idRegex = "[a-zA-Z0-9\\{](-[a-zA-Z0-9])-[a-zA-Z0-9]{12}";
+        String id2Regex = "[a-zA-Z0-9\\{](-[a-zA-Z0-9\\}])-[a-zA-Z0-9]{15}";
+        String emailRegex =
+                "(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|\""
+                        + "(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\["
+                        + "\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+"
+                        + "[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}"
+                        + "(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]"
+                        + ":(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]"
+                        + "|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])";
+
+        StringBuilder paramBuilder = new StringBuilder();
+        paramBuilder.append("/{name: ").append(nameRegex).append("}");
+        paramBuilder.append("/x");
+        paramBuilder.append("/{id: ").append(idRegex).append("}");
+        paramBuilder.append("/{id2: ").append(id2Regex).append("}");
+        paramBuilder.append("/{email:").append(emailRegex).append("}");
+
+        Map<String, String> regex = PathResolver.extractPathParameterRegex(paramBuilder.toString());
+        
+        // Then
+        assertThat(regex.get("name")).isEqualTo(nameRegex);
+        assertThat(regex.get("id")).isEqualTo(idRegex);
+        assertThat(regex.get("id2")).isEqualTo(id2Regex);
+        assertThat(regex.get("email")).isEqualTo(emailRegex);
+    }
+
+    @Test
+    public void nullShouldBeReturnedIfNoRegexIsDefined() {
+        // When
+    	Map<String, String> regex = PathResolver.extractPathParameterRegex("{id}/subpath/{sid}");
+
+        // Then
+        assertThat(regex.get("id")).isNull();
+        assertThat(regex.get("sid")).isNull();
+    }
+
+    @Test
+    public void nullShouldBeReturnedIfParameterIsNotDefined() {
+        // When
+    	Map<String, String> regex = PathResolver.extractPathParameterRegex("{id}/subpath/{sid}");
+
+        // Then
+        assertThat(regex.get("subpath")).isNull();
+    }
+}

--- a/gwtp-core/gwtp-dispatch-rest/src/main/resources/com/gwtplatform/dispatch/rest/DispatchRest.gwt.xml
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/resources/com/gwtplatform/dispatch/rest/DispatchRest.gwt.xml
@@ -8,6 +8,7 @@
     <inherits name="com.google.gwt.http.HTTP"/>
     <inherits name="com.google.gwt.json.JSON"/>
     <inherits name="com.github.nmorel.gwtjackson.GwtJackson"/>
+    <inherits name="com.google.gwt.logging.Logging"/>
 
     <!-- Specify the paths for translatable code -->
     <source path="client"/>

--- a/gwtp-core/gwtp-dispatch-rest/src/main/resources/com/gwtplatform/dispatch/rest/rebind/action/Action.vm
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/resources/com/gwtplatform/dispatch/rest/rebind/action/Action.vm
@@ -2,6 +2,7 @@ package $package;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import javax.ws.rs.core.HttpHeaders;
 
@@ -15,13 +16,18 @@ public class $impl extends AbstractRestAction<$result> {
     public ${impl}(
             HttpParameterFactory httpParameterFactory,
             String defaultDateFormat#generateAppendedMethodSignature($parameters)) {
-        super(httpParameterFactory, defaultDateFormat, HttpMethod.$httpVerb, "$path");
+        super(httpParameterFactory, defaultDateFormat, HttpMethod.$httpVerb, "$rawServicePath", "$path");
 
 #foreach($param in $httpParameters)
         addParam(Type.$param.type.getAssociatedType(), "$param.name", $param.variableName#if($param.dateFormat), "$param.dateFormat"#end);
 #end
 #if($bodyParameterName)
         setBodyParam($bodyParameterName);
+#end
+#if($pathParamRegexMapping)
+#foreach($entry in $pathParamRegexMapping.entrySet())
+        addParameterExpression($entry.getKey(), $entry.getValue());
+#end
 #end
     }
 

--- a/gwtp-core/gwtp-dispatch-rest/src/main/resources/com/gwtplatform/dispatch/rest/rebind/action/Action.vm
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/resources/com/gwtplatform/dispatch/rest/rebind/action/Action.vm
@@ -26,7 +26,7 @@ public class $impl extends AbstractRestAction<$result> {
 #end
 #if($pathParamRegexMapping)
 #foreach($entry in $pathParamRegexMapping.entrySet())
-        addParameterExpression($entry.getKey(), $entry.getValue());
+        addParameterExpression("$entry.getKey()", "$entry.getValue()");
 #end
 #end
     }

--- a/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/codegen/AbstractRestActionTest.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/codegen/AbstractRestActionTest.java
@@ -16,10 +16,6 @@
 
 package com.gwtplatform.dispatch.rest.client.codegen;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.tuple;
-import static org.junit.Assert.assertTrue;
-
 import org.junit.Before;
 import org.junit.Test;
 
@@ -27,6 +23,10 @@ import com.gwtplatform.dispatch.rest.client.testutils.MockHttpParameterFactory;
 import com.gwtplatform.dispatch.rest.client.testutils.SecuredRestAction;
 import com.gwtplatform.dispatch.rest.shared.HttpMethod;
 import com.gwtplatform.dispatch.rest.shared.HttpParameter.Type;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.junit.Assert.assertTrue;
 
 public class AbstractRestActionTest {
     private static final String PARAM_NAME_1 = "someName";

--- a/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/codegen/AbstractRestActionTest.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/codegen/AbstractRestActionTest.java
@@ -73,114 +73,13 @@ public class AbstractRestActionTest {
     }
 
     @Test
-    public void regexInformationShouldNotBePartOfPath() {
-        // When
-        action = new SecuredRestAction(new MockHttpParameterFactory(), HttpMethod.POST,
-                "{id: [0-9]*}/subpath/{sid:[0-9]{1,9}}");
-
-        // Then
-        assertThat(action.getPath()).isEqualTo("{id}/subpath/{sid}");
-    }
-
-    @Test
-    public void pathParameterWithoutRegexShouldNotBeChanged() {
+    public void pathParameterWithRegex_regExShouldBeRemovedFromPath() {
         // When
         action = new SecuredRestAction(new MockHttpParameterFactory(), HttpMethod.POST, "{id: [0-9]*}/subpath/{sid}");
 
         // Then
         assertThat(action.getPath()).isEqualTo("{id}/subpath/{sid}");
-    }
-
-    @Test
-    public void regexInformationCanBeRetrievedForParameter() {
-        // When
-        action = new SecuredRestAction(new MockHttpParameterFactory(), HttpMethod.POST, "{id: [0-9]*}/subpath");
-
-        // Then
         assertThat(action.getPathParameterRegex("id")).isEqualTo("[0-9]*");
-    }
-
-    @Test
-    public void multipleRegexInformationCanBeRetrievedForParameter() {
-        // When
-        String idRegex = "[0-9]*";
-        String sidRegex = "[0-9]{1,9}";
-        String imeiRegex = "[0-9\\:\\/]{15}";
-        StringBuilder paramBuilder = new StringBuilder();
-        paramBuilder.append("{id: ").append(idRegex).append("}");
-        paramBuilder.append("/subpath");
-        paramBuilder.append("/{sid: ").append(sidRegex).append("}");
-        paramBuilder.append("/mobile");
-        paramBuilder.append("/{imei: ").append(imeiRegex).append("}");
-
-        action = new SecuredRestAction(new MockHttpParameterFactory(), HttpMethod.POST, paramBuilder.toString());
-
-        // Then
-        assertThat(action.getPathParameterRegex("id")).isEqualTo(idRegex);
-        assertThat(action.getPathParameterRegex("sid")).isEqualTo(sidRegex);
-        assertThat(action.getPathParameterRegex("imei")).isEqualTo(imeiRegex);
-        assertThat(action.getPathParameterRegex("subpath")).isNull();
-        assertThat(action.getPathParameterRegex("mobile")).isNull();
-    }
-
-    @Test
-    public void regexWithEscapedAngleBracketsCanBeResolved() {
-        // When
-        String regex = "[a-zA-Z0-9\\{](-[a-zA-Z0-9])-[a-zA-Z0-9]{12}";
-        action = new SecuredRestAction(new MockHttpParameterFactory(), HttpMethod.POST,
-                "/{id:" + regex + "}");
-
-        // Then
-        assertThat(action.getPathParameterRegex("id")).isEqualTo(regex);
-    }
-
-    @Test
-    public void multipleAndMoreComplexRegexInformationCanBeRetrievedForParameter() {
-        // When
-        String nameRegex = "[0-9]*";
-        String idRegex = "[a-zA-Z0-9\\{](-[a-zA-Z0-9])-[a-zA-Z0-9]{12}";
-        String id2Regex = "[a-zA-Z0-9\\{](-[a-zA-Z0-9\\}])-[a-zA-Z0-9]{15}";
-        String emailRegex =
-                "(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|\""
-                        + "(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\["
-                        + "\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+"
-                        + "[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}"
-                        + "(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]"
-                        + ":(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]"
-                        + "|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])";
-
-        StringBuilder paramBuilder = new StringBuilder();
-        paramBuilder.append("/{name: ").append(nameRegex).append("}");
-        paramBuilder.append("/x");
-        paramBuilder.append("/{id: ").append(idRegex).append("}");
-        paramBuilder.append("/{id2: ").append(id2Regex).append("}");
-        paramBuilder.append("/{email:").append(emailRegex).append("}");
-
-        action = new SecuredRestAction(new MockHttpParameterFactory(), HttpMethod.POST, paramBuilder.toString());
-        // Then
-        assertThat(action.getPathParameterRegex("name")).isEqualTo(nameRegex);
-        assertThat(action.getPathParameterRegex("id")).isEqualTo(idRegex);
-        assertThat(action.getPathParameterRegex("id2")).isEqualTo(id2Regex);
-        assertThat(action.getPathParameterRegex("email")).isEqualTo(emailRegex);
-    }
-
-    @Test
-    public void nullShouldBeReturnedIfNoRegexIsDefined() {
-        // When
-        action = new SecuredRestAction(new MockHttpParameterFactory(), HttpMethod.POST, "{id}/subpath/{sid}");
-
-        // Then
-        assertThat(action.getPathParameterRegex("id")).isNull();
-        assertThat(action.getPathParameterRegex("sid")).isNull();
-    }
-
-    @Test
-    public void nullShouldBeReturnedIfParameterIsNotDefined() {
-        // When
-        action = new SecuredRestAction(new MockHttpParameterFactory(), HttpMethod.POST, "{id}/subpath/{sid}");
-
-        // Then
-        assertThat(action.getPathParameterRegex("subpath")).isNull();
     }
 
 }

--- a/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/testutils/ExposedRestAction.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/testutils/ExposedRestAction.java
@@ -18,9 +18,12 @@ package com.gwtplatform.dispatch.rest.client.testutils;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 
 import com.gwtplatform.dispatch.rest.client.codegen.AbstractRestAction;
 import com.gwtplatform.dispatch.rest.client.core.parameters.HttpParameterFactory;
+import com.gwtplatform.dispatch.rest.rebind.utils.PathResolver;
 import com.gwtplatform.dispatch.rest.shared.ContentType;
 import com.gwtplatform.dispatch.rest.shared.DateFormat;
 import com.gwtplatform.dispatch.rest.shared.HttpMethod;
@@ -40,10 +43,18 @@ public abstract class ExposedRestAction<R> extends AbstractRestAction<R> {
             HttpParameterFactory factory,
             HttpMethod httpMethod,
             String rawServicePath) {
-        super(factory, DateFormat.DEFAULT, httpMethod, rawServicePath);
+        super(factory, DateFormat.DEFAULT, httpMethod, rawServicePath, PathResolver.resolvePath(rawServicePath));
+        
+        // also resolve the regular expressions add them to the newly created instance
+        Map<String, String> regex = PathResolver.extractPathParameterRegex(rawServicePath);
+        if (regex != null) {        	
+        	for (Entry<String, String> entry : regex.entrySet()) {
+        		addParameterExpression(entry.getKey(), entry.getValue());
+        	}
+        }
     }
 
-    @Override
+	@Override
     public void setBodyParam(Object value) {
         super.setBodyParam(value);
     }

--- a/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/testutils/ExposedRestAction.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/client/testutils/ExposedRestAction.java
@@ -44,17 +44,17 @@ public abstract class ExposedRestAction<R> extends AbstractRestAction<R> {
             HttpMethod httpMethod,
             String rawServicePath) {
         super(factory, DateFormat.DEFAULT, httpMethod, rawServicePath, PathResolver.resolvePath(rawServicePath));
-        
+
         // also resolve the regular expressions add them to the newly created instance
         Map<String, String> regex = PathResolver.extractPathParameterRegex(rawServicePath);
-        if (regex != null) {        	
-        	for (Entry<String, String> entry : regex.entrySet()) {
-        		addParameterExpression(entry.getKey(), entry.getValue());
-        	}
+        if (regex != null) {
+            for (Entry<String, String> entry : regex.entrySet()) {
+                addParameterExpression(entry.getKey(), entry.getValue());
+            }
         }
     }
 
-	@Override
+    @Override
     public void setBodyParam(Object value) {
         super.setBodyParam(value);
     }

--- a/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/rebind/utils/PathResolverTest.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/test/java/com/gwtplatform/dispatch/rest/rebind/utils/PathResolverTest.java
@@ -1,18 +1,34 @@
-package com.gwtplatform.dispatch.rest.rebind.utils;
+/*
+ * Copyright 2015 ArcBees Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 
-import static org.assertj.core.api.Assertions.assertThat;
+package com.gwtplatform.dispatch.rest.rebind.utils;
 
 import java.util.Map;
 
 import org.junit.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 public class PathResolverTest {
 
     @Test
     public void regexInformationShouldNotBePartOfPath() {
-    	// When
+        // When
         String resolvedPath = PathResolver.resolvePath("{id: [0-9]*}/subpath/{sid:[0-9]{1,9}}");
-        
+
         // Then
         assertThat(resolvedPath).isEqualTo("{id}/subpath/{sid}");
     }
@@ -20,16 +36,16 @@ public class PathResolverTest {
     @Test
     public void pathParameterWithoutRegexShouldNotBeChanged() {
         // When
-    	String resolvedPath = PathResolver.resolvePath("{id: [0-9]*}/subpath/{sid}");
+        String resolvedPath = PathResolver.resolvePath("{id: [0-9]*}/subpath/{sid}");
 
         // Then
-    	assertThat(resolvedPath).isEqualTo("{id}/subpath/{sid}");
+        assertThat(resolvedPath).isEqualTo("{id}/subpath/{sid}");
     }
 
     @Test
     public void regexInformationCanBeRetrievedForParameter() {
-    	// When
-    	Map<String, String> regex = PathResolver.extractPathParameterRegex("{id: [0-9]*}/subpath");
+        // When
+        Map<String, String> regex = PathResolver.extractPathParameterRegex("{id: [0-9]*}/subpath");
 
         // Then
         assertThat(regex.get("id")).isEqualTo("[0-9]*");
@@ -59,7 +75,7 @@ public class PathResolverTest {
 
     @Test
     public void regexWithEscapedAngleBracketsCanBeResolved() {
-    	// When
+        // When
         String regex = "[a-zA-Z0-9\\{](-[a-zA-Z0-9])-[a-zA-Z0-9]{12}";
         Map<String, String> regexMap = PathResolver.extractPathParameterRegex(
                 "/{id:[a-zA-Z0-9\\{](-[a-zA-Z0-9])-[a-zA-Z0-9]{12}}");
@@ -91,7 +107,7 @@ public class PathResolverTest {
         paramBuilder.append("/{email:").append(emailRegex).append("}");
 
         Map<String, String> regex = PathResolver.extractPathParameterRegex(paramBuilder.toString());
-        
+
         // Then
         assertThat(regex.get("name")).isEqualTo(nameRegex);
         assertThat(regex.get("id")).isEqualTo(idRegex);
@@ -102,7 +118,7 @@ public class PathResolverTest {
     @Test
     public void nullShouldBeReturnedIfNoRegexIsDefined() {
         // When
-    	Map<String, String> regex = PathResolver.extractPathParameterRegex("{id}/subpath/{sid}");
+        Map<String, String> regex = PathResolver.extractPathParameterRegex("{id}/subpath/{sid}");
 
         // Then
         assertThat(regex.get("id")).isNull();
@@ -112,7 +128,7 @@ public class PathResolverTest {
     @Test
     public void nullShouldBeReturnedIfParameterIsNotDefined() {
         // When
-    	Map<String, String> regex = PathResolver.extractPathParameterRegex("{id}/subpath/{sid}");
+        Map<String, String> regex = PathResolver.extractPathParameterRegex("{id}/subpath/{sid}");
 
         // Then
         assertThat(regex.get("subpath")).isNull();


### PR DESCRIPTION
Hi everyone :)

We discovered an unsupported feature of the JSR 311 in the gwt-dispatch-rest project.
According to the specification (section 3.4 - URI Templates) it is allowed to define regular expressions for the path parameters.
The consequence are errors during the path parameter substitution if such regular expressions are defined.
We implemented the extraction of the regular expressions during the compile / client stub generation (RestActionGenerator) as well as a runtime check of the parameter substitution against the regular expression (DefaultUriFactor - only if the client side logging is activated, otherwise the regex will be ignored).