### PR TITLE
ViewWithUiHandlers: Correct the logged advice when uiHandlers is null

### DIFF
--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/ViewWithUiHandlers.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/client/ViewWithUiHandlers.java
@@ -44,7 +44,9 @@ public abstract class ViewWithUiHandlers<C extends UiHandlers> extends ViewImpl
      */
     protected C getUiHandlers() {
         if (uiHandlers == null) {
-            logger.severe("uiHandlers are not set.  Did you call getUiHandlers() from your view's constructor?");
+            logger.severe("uiHandlers are not set. You should call " +
+                    "setUiHandlers() from your presenter's constructor to make " +
+                    "the UiHandlers instance available.");
         }
         return uiHandlers;
     }


### PR DESCRIPTION
The log messages suggests that you need to call getUiHandlers() to make getUIHandlers(). But it's setUIHandlers that you need to call. And this is apparently usually called from the presenter's constructor, not the view's constructor. For instance: http://blog.arcbees.com/2015/04/01/gwt-platform-event-best-practices-revisited/

The questioning form was also unclear, as if that's what you shouldn't have done, rather than it being what you should do. So I made it more obvious.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/arcbees/gwtp/761)
<!-- Reviewable:end -->
