### PR TITLE
Remove processLast from bindings processors.

### DIFF
--- a/gwtp-core/gwtp-clients-common/src/main/java/com/gwtplatform/common/processors/module/GwtpAppModuleProcessor.java
+++ b/gwtp-core/gwtp-clients-common/src/main/java/com/gwtplatform/common/processors/module/GwtpAppModuleProcessor.java
@@ -33,6 +33,7 @@ import com.gwtplatform.processors.tools.domain.Type;
 import com.gwtplatform.processors.tools.utils.MetaInfResource;
 
 import static com.google.auto.common.MoreElements.asType;
+import static com.gwtplatform.processors.tools.bindings.BindingContext.flushModule;
 import static com.gwtplatform.processors.tools.bindings.BindingContext.newModule;
 import static com.gwtplatform.processors.tools.bindings.BindingContext.newSubModule;
 
@@ -70,7 +71,7 @@ public class GwtpAppModuleProcessor extends AbstractGwtpAppProcessor {
         installModules(extractModules(roundEnv));
 
         if (roundEnv.processingOver()) {
-            bindingsProcessors.processLast();
+            bindingsProcessors.process(flushModule(MAIN_MODULE_TYPE));
         }
     }
 

--- a/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/processors/DispatchRestProcessor.java
+++ b/gwtp-core/gwtp-dispatch-rest/src/main/java/com/gwtplatform/dispatch/rest/processors/DispatchRestProcessor.java
@@ -71,7 +71,7 @@ public class DispatchRestProcessor extends AbstractProcessor {
         boolean elementsProcessed = processGwtElements(roundEnv);
 
         if (elementsProcessed) {
-            flushBindingsProcessors();
+            bindingsProcessors.process(flushModule(findRestModuleType(utils)));
         }
 
         maybeProcessLastRound(roundEnv);
@@ -101,15 +101,10 @@ public class DispatchRestProcessor extends AbstractProcessor {
         }
     }
 
-    private void flushBindingsProcessors() {
-        bindingsProcessors.process(flushModule(findRestModuleType(utils)));
-    }
-
     private void maybeProcessLastRound(RoundEnvironment roundEnv) {
         if (roundEnv.processingOver()) {
             resourceProcessor.processLast();
             serializationProcessors.processLast();
-            bindingsProcessors.processLast();
         }
     }
 }

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/processors/entrypoint/EntryPointProcessor.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/processors/entrypoint/EntryPointProcessor.java
@@ -71,10 +71,6 @@ public class EntryPointProcessor extends AbstractProcessor {
 
             generated = true;
         }
-
-        if (generated && roundEnv.processingOver()) {
-            bindingsProcessors.processLast();
-        }
     }
 
     private TypeElement findGwtpAppElement(RoundEnvironment roundEnv) {

--- a/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/processors/proxy/MainProxyProcessor.java
+++ b/gwtp-core/gwtp-mvp-client/src/main/java/com/gwtplatform/mvp/processors/proxy/MainProxyProcessor.java
@@ -44,7 +44,6 @@ public class MainProxyProcessor extends AbstractProcessor {
 
     private Factory proxyFactory;
 
-    private BindingsProcessors bindingsProcessors;
     private ProxyProcessors proxyProcessors;
     private ProxyModules proxyModules;
     private NamedProviderBundleProcessor providerBundleProcessor;
@@ -57,8 +56,7 @@ public class MainProxyProcessor extends AbstractProcessor {
     @Override
     protected void initSafe() {
         proxyFactory = new ProxyDetailsFactory(logger, utils);
-        bindingsProcessors = new BindingsProcessors(logger, utils, outputter);
-        proxyModules = new ProxyModules(utils, bindingsProcessors);
+        proxyModules = new ProxyModules(utils, new BindingsProcessors(logger, utils, outputter));
         providerBundleProcessor = new NamedProviderBundleProcessor();
         proxyProcessors = new ProxyProcessors(logger, utils, outputter, proxyModules, providerBundleProcessor);
 
@@ -105,7 +103,6 @@ public class MainProxyProcessor extends AbstractProcessor {
         if (roundEnv.processingOver()) {
             providerBundleProcessor.processLast();
             proxyProcessors.processLast();
-            bindingsProcessors.processLast();
         }
     }
 }

--- a/processor-tools/src/main/java/com/gwtplatform/processors/tools/AbstractProcessor.java
+++ b/processor-tools/src/main/java/com/gwtplatform/processors/tools/AbstractProcessor.java
@@ -58,7 +58,7 @@ public abstract class AbstractProcessor extends javax.annotation.processing.Abst
 
     @Override
     public Set<String> getSupportedAnnotationTypes() {
-        SupportedAnnotationTypes supportedTypes = this.getClass().getAnnotation(SupportedAnnotationTypes.class);
+        SupportedAnnotationTypes supportedTypes = getClass().getAnnotation(SupportedAnnotationTypes.class);
         SupportedAnnotationClasses supportedClasses = getClass().getAnnotation(SupportedAnnotationClasses.class);
 
         Set<String> supportedAnnotations = new HashSet<>();

--- a/processor-tools/src/main/java/com/gwtplatform/processors/tools/bindings/BindingsProcessors.java
+++ b/processor-tools/src/main/java/com/gwtplatform/processors/tools/bindings/BindingsProcessors.java
@@ -26,7 +26,6 @@ public class BindingsProcessors {
     private static final String NO_BINDING_POLICIES_FOUND = "Can not find a binding policy for `%s`.";
 
     private static ServiceLoader<BindingsProcessor> processors;
-    private static boolean processedLast;
     private static boolean initialized;
 
     private final Logger logger;
@@ -60,18 +59,6 @@ public class BindingsProcessors {
 
         if (!processed) {
             logger.mandatoryWarning(NO_BINDING_POLICIES_FOUND, context);
-        }
-    }
-
-    public void processLast() {
-        ensureInitialized();
-
-        if (!processedLast) {
-            processedLast = true;
-
-            for (BindingsProcessor processor : processors) {
-                processor.processLast();
-            }
         }
     }
 

--- a/processor-tools/src/main/java/com/gwtplatform/processors/tools/bindings/gin/GinModuleProcessor.java
+++ b/processor-tools/src/main/java/com/gwtplatform/processors/tools/bindings/gin/GinModuleProcessor.java
@@ -123,13 +123,6 @@ public class GinModuleProcessor extends AbstractContextProcessor<BindingContext,
         setBinders.remove(moduleType);
     }
 
-    @Override
-    public void processLast() {
-        for (Type moduleType : sourceFiles.keySet()) {
-            outputModule(moduleType);
-        }
-    }
-
     private void outputModule(Type moduleType) {
         logger.debug("Generating GIN module `%s`.", moduleType.getQualifiedName());
 


### PR DESCRIPTION
This is to prevent race conditions between multiple processors.
ie: A processor closes a module that is still required by another
processor.