### PR TITLE
Upgrade Servlet API to 3.1.0

### DIFF
--- a/gwtp-core/gwtp-crawler/pom.xml
+++ b/gwtp-core/gwtp-crawler/pom.xml
@@ -33,7 +33,7 @@
     <dependencies>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
 
         <!-- DI dependencies -->

--- a/gwtp-core/pom.xml
+++ b/gwtp-core/pom.xml
@@ -222,8 +222,8 @@
             <!-- Standard Java extension jars -->
             <dependency>
                 <groupId>javax.servlet</groupId>
-                <artifactId>servlet-api</artifactId>
-                <version>${servlet-api.version}</version>
+                <artifactId>javax.servlet-api</artifactId>
+                <version>${javax.servlet-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>javax.inject</groupId>

--- a/gwtp-crawler-service/pom.xml
+++ b/gwtp-crawler-service/pom.xml
@@ -29,8 +29,8 @@
     <dependencies>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
-            <version>${servlet-api.version}</version>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>${javax.servlet-api.version}</version>
         </dependency>
         <dependency>
             <groupId>javax.inject</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -273,7 +273,7 @@
         <guava.version>18.0</guava.version>
         <objectify.version>5.0.2</objectify.version>
         <persistence-api.version>1.0</persistence-api.version>
-        <servlet-api.version>2.5</servlet-api.version>
+        <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
         <spring.version>4.0.5.RELEASE</spring.version>
         <velocity.version>1.7</velocity.version>
         <auto-common.version>1.0-SNAPSHOT</auto-common.version>


### PR DESCRIPTION
Running SuperDevMode for a GWTP app using GWT 2.8.0-rc1 throws a `java.lang.NoSuchMethodError` due to conflicting Servlet APIs: The Jetty web server bundled with 2.8.0-rc1 depends on 3.1.0 whereas GWTP still uses 2.5.0 (see also https://groups.google.com/d/msg/google-web-toolkit/S9KV1GaCyvg/gEp918awAQAJ). 

This PR upgrades the Servlet API to 3.1.0. Running a quick `mvn clean install` did not show any problems in using 3.1.0