### PR TITLE
delegate DispatchService log handling to a separate log handler

### DIFF
--- a/gwtp-core/gwtp-dispatch-rpc-server-guice/src/main/java/com/gwtplatform/dispatch/rpc/server/guice/DispatchServiceImpl.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-guice/src/main/java/com/gwtplatform/dispatch/rpc/server/guice/DispatchServiceImpl.java
@@ -16,14 +16,13 @@
 
 package com.gwtplatform.dispatch.rpc.server.guice;
 
-import java.util.logging.Logger;
-
 import javax.inject.Singleton;
 
 import com.google.inject.Inject;
 import com.gwtplatform.dispatch.rpc.server.AbstractDispatchServiceImpl;
 import com.gwtplatform.dispatch.rpc.server.Dispatch;
 import com.gwtplatform.dispatch.rpc.server.RequestProvider;
+import com.gwtplatform.dispatch.rpc.server.logger.DispatchServiceLogHandler;
 import com.gwtplatform.dispatch.shared.SecurityCookie;
 
 /**
@@ -50,7 +49,8 @@ public class DispatchServiceImpl extends AbstractDispatchServiceImpl {
     protected String securityCookieName;
 
     @Inject
-    public DispatchServiceImpl(final Logger logger, final Dispatch dispatch, RequestProvider requestProvider) {
+    public DispatchServiceImpl(final DispatchServiceLogHandler logger, final Dispatch dispatch, RequestProvider
+            requestProvider) {
         super(logger, dispatch, requestProvider);
     }
 

--- a/gwtp-core/gwtp-dispatch-rpc-server-guice/src/main/java/com/gwtplatform/dispatch/rpc/server/guice/logger/DefaultDispatchServiceLogHandlerImpl.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-guice/src/main/java/com/gwtplatform/dispatch/rpc/server/guice/logger/DefaultDispatchServiceLogHandlerImpl.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2016 ArcBees Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.gwtplatform.dispatch.rpc.server.guice.logger;
+
+import java.util.logging.Logger;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.gwtplatform.dispatch.rpc.server.logger.AbstractDispatchServiceLogHandlerImpl;
+
+/**
+ * Guice implementation of the {@link com.gwtplatform.dispatch.rpc.server.logger.DispatchServiceLogHandler}.
+ *
+ * @author Filip Hrisafov
+ */
+@Singleton
+public class DefaultDispatchServiceLogHandlerImpl extends AbstractDispatchServiceLogHandlerImpl {
+
+    @Inject
+    public DefaultDispatchServiceLogHandlerImpl(Logger logger) {
+        super(logger);
+    }
+}

--- a/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/rpc/server/spring/DispatchServiceImpl.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/rpc/server/spring/DispatchServiceImpl.java
@@ -17,7 +17,6 @@
 package com.gwtplatform.dispatch.rpc.server.spring;
 
 import java.io.IOException;
-import java.util.logging.Logger;
 
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
@@ -33,6 +32,7 @@ import org.springframework.web.context.ServletContextAware;
 import com.gwtplatform.dispatch.rpc.server.AbstractDispatchServiceImpl;
 import com.gwtplatform.dispatch.rpc.server.Dispatch;
 import com.gwtplatform.dispatch.rpc.server.RequestProvider;
+import com.gwtplatform.dispatch.rpc.server.logger.DispatchServiceLogHandler;
 
 /**
  * Dispatch request to the handler.
@@ -48,7 +48,7 @@ public class DispatchServiceImpl extends AbstractDispatchServiceImpl implements 
     private ServletContext servletContext;
 
     @Autowired
-    public DispatchServiceImpl(Logger logger, Dispatch dispatch, RequestProvider requestProvider) {
+    public DispatchServiceImpl(DispatchServiceLogHandler logger, Dispatch dispatch, RequestProvider requestProvider) {
         super(logger, dispatch, requestProvider);
     }
 

--- a/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/rpc/server/spring/logger/DefaultDispatchServiceLogHandlerImpl.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server-spring/src/main/java/com/gwtplatform/dispatch/rpc/server/spring/logger/DefaultDispatchServiceLogHandlerImpl.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2016 ArcBees Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.gwtplatform.dispatch.rpc.server.spring.logger;
+
+import java.util.logging.Logger;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.gwtplatform.dispatch.rpc.server.logger.AbstractDispatchServiceLogHandlerImpl;
+
+/**
+ * Spring implementation of the {@link com.gwtplatform.dispatch.rpc.server.logger.DispatchServiceLogHandler}.
+ *
+ * @author Filip Hrisafov
+ */
+@Component("dispatchServiceLogHandler")
+public class DefaultDispatchServiceLogHandlerImpl extends AbstractDispatchServiceLogHandlerImpl {
+
+    @Autowired
+    public DefaultDispatchServiceLogHandlerImpl(Logger logger) {
+        super(logger);
+    }
+}

--- a/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/rpc/server/logger/AbstractDispatchServiceLogHandlerImpl.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/rpc/server/logger/AbstractDispatchServiceLogHandlerImpl.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2016 ArcBees Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.gwtplatform.dispatch.rpc.server.logger;
+
+import java.text.MessageFormat;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import com.gwtplatform.dispatch.rpc.server.AbstractDispatchServiceImpl.DispatchType;
+import com.gwtplatform.dispatch.rpc.shared.Action;
+import com.gwtplatform.dispatch.rpc.shared.ServiceException;
+import com.gwtplatform.dispatch.shared.ActionException;
+
+/**
+ * This is the server-side implementation of the {@link DispatchServiceLogHandler}. The implementation transfers the
+ * logging to the underlying {@link Logger}. If you need different logging then instantiate your own {@link
+ * DispatchServiceLogHandler}.
+ *
+ * @author Filip Hrisafov
+ */
+public class AbstractDispatchServiceLogHandlerImpl implements DispatchServiceLogHandler {
+
+    private static final String ACTION_EXCEPTION_MSG = "Action exception while {0} {1}: {2}";
+    private static final String SERVICE_EXCEPTION_MSG = "Service exception while {0} {1}: {2}";
+    private static final String UNEXPECTED_EXCEPTION_MSG = "Unexpected exception while {0} {1}: {2}";
+
+    private final Logger logger;
+
+    protected AbstractDispatchServiceLogHandlerImpl(Logger logger) {
+        this.logger = logger;
+    }
+
+    @Override
+    public void severe(String message) {
+        logger.severe(message);
+    }
+
+    @Override
+    public void log(Throwable throwable, Action<?> action, DispatchType type) {
+        if (throwable instanceof ActionException) {
+            warn(throwable, action, type, ACTION_EXCEPTION_MSG);
+        } else if (throwable instanceof ServiceException) {
+            warn(throwable, action, type, SERVICE_EXCEPTION_MSG);
+        } else {
+            warn(throwable, action, type, UNEXPECTED_EXCEPTION_MSG);
+        }
+    }
+
+    private void warn(Throwable throwable, Action<?> action, DispatchType type, String pattern) {
+        if (logger.isLoggable(Level.WARNING)) {
+            logger.log(Level.WARNING, MessageFormat
+                    .format(pattern, messageForDispatch(type), action.getClass().getName(), throwable.getMessage(),
+                            throwable));
+        }
+    }
+
+    @Override
+    public void info(String message) {
+        logger.info(message);
+    }
+
+    protected String messageForDispatch(DispatchType type) {
+        String message = "unknown";
+        if (type != null) {
+            switch (type) {
+                case Execute:
+                    message = "executing";
+                    break;
+                case Undo:
+                    message = "undoing";
+                    break;
+            }
+        }
+        return message;
+    }
+}

--- a/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/rpc/server/logger/DispatchServiceLogHandler.java
+++ b/gwtp-core/gwtp-dispatch-rpc-server/src/main/java/com/gwtplatform/dispatch/rpc/server/logger/DispatchServiceLogHandler.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2016 ArcBees Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.gwtplatform.dispatch.rpc.server.logger;
+
+import com.gwtplatform.dispatch.rpc.server.AbstractDispatchServiceImpl.DispatchType;
+import com.gwtplatform.dispatch.rpc.shared.Action;
+
+/**
+ * Log handler for the {@link com.gwtplatform.dispatch.rpc.shared.DispatchService}. All the log statements and caught
+ * Exceptions in the {@link com.gwtplatform.dispatch.rpc.shared.DispatchService} are send to this interface.
+ *
+ * @author Filip Hrisafov
+ */
+public interface DispatchServiceLogHandler {
+
+    /**
+     * A message that needs to be logged at info level.
+     *
+     * @param message to be logged
+     */
+    void info(String message);
+
+    /**
+     * Log a {@link Throwable} during the execution of an action or during undoing an action.
+     *
+     * @param throwable the throwable
+     * @param action the action for which an exception occurred
+     * @param type the type of the method in which the exception occurred
+     */
+    void log(Throwable throwable, Action<?> action, DispatchType type);
+
+    /**
+     * A message that needs to be logged at the severe level.
+     *
+     * @param message to be logged
+     */
+    void severe(String message);
+}


### PR DESCRIPTION
I have extracted the `DispatchService` Log handling to a separate handler. This resolves #803 and provides an easier way to customize the way the exceptions are logged.
