### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,2 +1,2 @@
-##Contributing Guidelines
+## Contributing Guidelines
 See http://dev.arcbees.com/gwtp/contributing/Contributing-Guidelines.html

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,3 +1,3 @@
-#License
+# License
 
 GWTP is freely distributable under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).

--- a/README.md
+++ b/README.md
@@ -3,41 +3,41 @@
 *goo-teepee*
 A complete model-view-presenter framework to simplify your next GWT project.
 
-##Enterprise Support
+## Enterprise Support
 Get high quality support through ArcBees.
 
 * <a href="http://gwtp.arcbees.com">Enterprise Support Features</a>
 * <a href="http://www.arcbees.com/en/#!/support">Buy Enterprise Support</a>
 
-##Reference
+## Reference
 * [GWTP Custom Google Search](http://www.google.com/cse/home?cx=011138278718949652927:5yuja8xc600) - Search all of the GWTP documentation, wiki and thread collections.
 * [GWTP Documentation](http://dev.arcbees.com/gwtp/) - Find out how to use GWT-Platform here.
 * [GWTP Samples](https://github.com/ArcBees/GWTP-Samples) - Find Sample GWT-Platform projects here.
 * [GWTP Archetypes](https://github.com/ArcBees/Arcbees-Archetypes/tree/master/archetypes) - Start a project from a template here.
 
-##Plugins
+## Plugins
 * [Eclipse Plugin](https://github.com/ArcBees/gwtp-eclipse-plugin) - Create project and presenters
 * [IntelliJ IDEA Plugin](https://github.com/ArcBees/gwtp-idea-plugin) - Create project and presenters
 
-##Community
+## Community
 * [Join the GWT-Platform G+ Community](https://plus.google.com/communities/113139554133824081251) - See whats happening in the community.
 * [GWTP Google Group](https://groups.google.com/forum/?fromgroups#!forum/gwt-platform) - Ask for help here.
 
-##Maven
+## Maven
 * [Maven Configuration Instructions](https://github.com/ArcBees/GWTP/wiki/Maven-Configuration)
 * [See whats available in Maven Central](http://search.maven.org/#search%7Cga%7C1%7Ccom.gwtplatform)
 
-##Downloads
+## Downloads
 * [Latest Jars in Maven Central](http://search.maven.org/#search%7Cga%7C1%7Ccom.gwtplatform) - Download jars from maven central.
 * See the manual dependency download section in [Maven Configuration Instructions](https://github.com/ArcBees/GWTP/wiki/Maven-Configuration) 
 
-###Current Release
+### Current Release
 1.6 - Released on 17 January 2017
 
-###Current Snapshot
+### Current Snapshot
 2.0-SNAPSHOT
 
-##Demos
+## Demos
 * [GWTP Samples Project Home](https://github.com/ArcBees/GWTP-Samples)
 <table>
   <tr>
@@ -72,17 +72,17 @@ Get high quality support through ArcBees.
   </tr>
 </table>
 
-##Implementers
+## Implementers
 * [ArcBees.com](http://arcbees.com)
 * [Jukito](http://jukito.arcbees.com/)
 
-##Javadocs
+## Javadocs
 * [Javadocs](http://arcbees.github.com/GWTP/javadoc/apidocs/index.html)
 
-##License
+## License
 * GWTP is freely distributable under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html)
 
-##Thanks to
+## Thanks to
 [![Arcbees.com](http://i.imgur.com/HDf1qfq.png)](http://arcbees.com)
 
 [![Atlassian](http://i.imgur.com/BKkj8Rg.png)](https://www.atlassian.com/)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
